### PR TITLE
Run `grunt` only once at Docker container start

### DIFF
--- a/setup/docker/01_setup_enketo.bash
+++ b/setup/docker/01_setup_enketo.bash
@@ -10,5 +10,3 @@ python setup/docker/create_config.py
 
 # Build.
 grunt
-# FIXME: Now that the client config. has been built, build again as a workaround to a `grunt` task sequencing issue.
-grunt


### PR DESCRIPTION
I tested this and could not see any ill effects from removing the second `grunt` call.

For my reference, this makes some progress toward resolving kobotoolbox/tasks#140.