### PR TITLE
Sort keys when writing JSON in `create_config.py`

### DIFF
--- a/setup/docker/create_config.py
+++ b/setup/docker/create_config.py
@@ -8,7 +8,7 @@ PROJECT_ROOT_PATH = os.path.abspath(os.path.join(CURRENT_DIR_PATH, '../..'))
 
 
 def get_or_create_encryption_key():
-    '''Automate the inconvenient task of generating and maintaining a consistent 
+    '''Automate the inconvenient task of generating and maintaining a consistent
        encryption key.'''
     # Attempt to get the key from an environment variable.
     encryption_key = os.environ.get('ENKETO_ENCRYPTION_KEY')
@@ -49,7 +49,7 @@ def create_config():
 
     # Retrieve/generate the encryption key if not present.
     config['linked form and data server'].setdefault('encryption key', get_or_create_encryption_key())
-    
+
     # Set the Docker Redis settings.
     config.setdefault('redis', dict()).setdefault('main', dict()).setdefault('host', 'redis_main')
     config['redis'].setdefault('cache', dict()).setdefault('host', 'redis_cache')
@@ -57,7 +57,7 @@ def create_config():
 
     # Write the potentially-updated config file to disk.
     with open(CONFIG_FILE_PATH, 'w') as config_file:
-        config_file.write(json.dumps(config, indent=4))
+        config_file.write(json.dumps(config, indent=4, sort_keys=True))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Keeping the order of `config.json` consistent from one run to the next helps to
avoid unnecessary `grunt` builds. Fixes #99.

Includes a few changes to remove extraneous whitespace.