### PR TITLE
added: automated Docker Hub builds

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -1,0 +1,21 @@
+name: Build and push image to Docker Hub
+
+on:
+  push:
+    # Don't waste time building every push: consider only tags, which are
+    # usually releases
+    tags:
+      - '*'
+
+jobs:
+  docker-build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: mr-smithers-excellent/docker-build-push@v2
+        with:
+          image: kobotoolbox/enketo-express
+          registry: docker.io
+          dockerfile: Dockerfile
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: mr-smithers-excellent/docker-build-push@v2
         with:
-          image: kobotoolbox/enketo-express
+          image: enketo/enketo-express
           registry: docker.io
           dockerfile: Dockerfile
           username: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
…using GitHub Actions. For each tag pushed to GitHub, a Docker image is built
and published to https://hub.docker.com/r/kobotoolbox/enketo-express.

I've added the referenced secrets to https://github.com/enketo/enketo-express/settings/secrets.