### PR TITLE
Generate encryption key at the root level of config.json if it does not exist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ##### Changed
 - Changed when dataupdate event is fired for setvalue/odk-instance-first-load actions to facilitate custom clients with field submissions (like OpenClinica).
 
+##### Fixed
+- Docker `create_config.py` script stored `encryption key` in the wrong place
+
 [2.3.6] - 2020-06-12
 ----------------------
 ##### Changed

--- a/setup/docker/create_config.py
+++ b/setup/docker/create_config.py
@@ -8,8 +8,10 @@ PROJECT_ROOT_PATH = os.path.abspath(os.path.join(CURRENT_DIR_PATH, '../..'))
 
 
 def get_or_create_encryption_key():
-    '''Automate the inconvenient task of generating and maintaining a consistent
-       encryption key.'''
+    """
+    Automate the inconvenient task of generating and maintaining a consistent
+    encryption key.
+    """
     # Attempt to get the key from an environment variable.
     encryption_key = os.environ.get('ENKETO_ENCRYPTION_KEY')
 
@@ -48,7 +50,7 @@ def create_config():
         raise EnvironmentError('An API key for Enketo Express is required.')
 
     # Retrieve/generate the encryption key if not present.
-    config['linked form and data server'].setdefault('encryption key', get_or_create_encryption_key())
+    config.setdefault('encryption key', get_or_create_encryption_key())
 
     # Set the Docker Redis settings.
     config.setdefault('redis', dict()).setdefault('main', dict()).setdefault('host', 'redis_main')


### PR DESCRIPTION
When `encryption key` is not present in `config.json`, a script at start-up generates a new one and injects it into the configuration file under `linked form and data server`.
According to the code, it should be at root level.

- https://github.com/enketo/enketo-express/blob/master/app/controllers/authentication-controller.js#L82
- https://github.com/enketo/enketo-express/blob/master/app/models/user-model.js#L24