### PR TITLE
Read csrf token if it exists and add to submission

### DIFF
--- a/public/js/src/module/connection.js
+++ b/public/js/src/module/connection.js
@@ -51,7 +51,7 @@ function uploadRecord( record ) {
         batch.deprecatedId = record.deprecatedId;
     } );
 
-    // Perform batch uploads sequentially for to avoid issues when connections are very poor and 
+    // Perform batch uploads sequentially for to avoid issues when connections are very poor and
     // a serious issue with ODK Aggregate (https://github.com/kobotoolbox/enketo-express/issues/400)
     return batches.reduce( ( prevPromise, batch ) => prevPromise.then( () => _uploadBatch( batch ) ), Promise.resolve() )
         .then( results => {
@@ -184,6 +184,8 @@ function _prepareFormDataArray( record ) {
         const fd = new FormData();
 
         fd.append( 'xml_submission_file', xmlSubmissionBlob, 'xml_submission_file' );
+        const csrfToken = ( document.cookie.split( '; ' ).find( c => c.startsWith( '__csrf' ) ) || '' ).split( '=' )[1];
+        if ( csrfToken ) fd.append( '__csrf', csrfToken );
 
         // batch with XML data
         batchPrepped = {

--- a/tutorials/10-configure.md
+++ b/tutorials/10-configure.md
@@ -42,9 +42,9 @@ This is the default authentication that lets Enketo collect credentials from the
 
 ##### External cookie authentication
 
-This allows a deeper integration for a custom server. It configures a (required) `url` on your form/data server where Enketo should redirect a user to when the server returns a 401 response. That url should set a cookie that Enketo will pass to the server whenever it needs to retrieve a form resource or submit data. The url should contain a {RETURNURL} portion which Enketo will populate to send the user back to the webform once authentication has completed.
+This allows a deeper integration with a custom server. To use cookie auth, your Enketo configuration must define a `url` on your form/data server where Enketo should redirect a user to when the server returns a 401 response. That url should set a cookie that Enketo will pass to the server whenever it needs to retrieve a form resource or submit data. The url should contain a {RETURNURL} portion which Enketo will populate to send the user back to the webform once authentication has completed.
 
-This mechanism requires any enketo-express webform to have access to these browser cookies so the form/data server and Enketo Express would have to be on the same domain (a different subdomain is possible when setting cross-domain cookies).
+Cookie authentication is vulnerable to Cross-Site Request Forgery (CSRF) attacks in which a malicious website could trick the user into submitting bad data to the data server by forwarding the same authentication cookie as Enketo does. To protect against this, the data server should set the [`SameSite`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) attribute as strictly as possible. However, this may not be respected by all browsers and may not be appropriate for all data server implementations because of other cookie-based integrations. For additional protection, if the data server provides a JavaScript-readable `__csrf` cookie field, Enketo will include a `__csrf` form data field on the submission `POST` with the value from the `__csrf` cookie. This allows the data server to verify that the `POST` definitively came from the same origin.
 
 ```json
 "authentication" : {


### PR DESCRIPTION
Closes #187

Notes on behavior:
- A submission can be divided in batches. The `__csrf` form data field will be added to each batch's `POST`.
- If a readable `__csrf` cookie exists, **regardless of auth type**, Enketo will include a `__csrf` form data field in the submission.

I was initially intending to only look for the cookie field if cookie auth was configured. But it seems to me like the check isn't necessary because if the data server doesn't know anything about this feature it just won't send the `__csrf` cookie so it won't be there for the client to see. It seems vanishingly unlikely that a data server would set a `__csrf` cookie field but then be unable to handle `__csrf` in the submission `POST`.

I verified this by running Enketo and Central locally with Enketo using local Central as the data server with basic auth and insecure transport. I built an Enketo link on top of an App user URL to not have to deal with auth. I manually wrote a `__csrf` cookie with value `foo` in Chrome. I filled out an Enketo record and verified that the submission form data includes a `__csrf` field with value `foo` (in addition to `xml_submission_file`). I also verified that if I remove the `__csrf` cookie field, everything works as expected.

I went into some background information in the docs because I think it's hard to protect against something that's not well-understood. I'm hoping that providing a little bit of general context will help folks make better security decisions.

I was hoping to drive this out with tests but I'm not seeing a good way to do so without significant restructuring. Ideally I could do something like fake having a `__csrf` cookie field and then verify that it's part of the `POST` data that goes from frontend to backend.
