### PR TITLE
Remove redundant form type check

### DIFF
--- a/public/js/src/module/settings.js
+++ b/public/js/src/module/settings.js
@@ -62,18 +62,7 @@ settings.languageOverrideParameter = queryParams.lang ? {
 // set default maxSubmissionSize
 settings.maxSize = DEFAULT_MAX_SIZE;
 
-// add type
-if ( window.location.pathname.indexOf( '/preview' ) === 0 ) {
-    settings.type = 'preview';
-} else if ( window.location.pathname.indexOf( '/single' ) === 0 ) {
-    settings.type = 'single';
-} else if ( window.location.pathname.indexOf( '/edit' ) === 0 ) {
-    settings.type = 'edit';
-} else if ( window.location.pathname.indexOf( '/view' ) === 0 ) {
-    settings.type = 'view';
-} else {
-    settings.type = 'other';
-}
+settings.type = settings.type || 'other';
 
 // Determine whether view is offline-capable
 settings.offline = window.location.pathname.includes( '/x/' );


### PR DESCRIPTION
Closes #195 

The removed checks only works if Enketo is at the server root. It shouldn't be necessary because survey-controller sets the form type.

I think this approach is safe but also provided #197 in case this feels too risky or there's something I don't know about why this code block exists.

Ideas for an automated test very welcome. I manually verified `preview`, `single`, and `xform` prefixes. I don't easily have the ability to verify `edit` or `view` prefixes but they're set the same way by `survey-controller`.

CC @matthew-white