### PR TITLE
Identify form type prefix when Enketo at subpath

### DIFF
--- a/public/js/src/module/settings.js
+++ b/public/js/src/module/settings.js
@@ -63,7 +63,7 @@ settings.languageOverrideParameter = queryParams.lang ? {
 settings.maxSize = DEFAULT_MAX_SIZE;
 
 // add type
-if ( window.location.pathname.includes( '/preview/' ) ) {
+if ( window.location.pathname.includes( '/preview/' ) || window.location.pathname.endsWith('/preview') ) {
     settings.type = 'preview';
 } else if ( window.location.pathname.includes( '/single/' ) ) {
     settings.type = 'single';

--- a/public/js/src/module/settings.js
+++ b/public/js/src/module/settings.js
@@ -63,13 +63,13 @@ settings.languageOverrideParameter = queryParams.lang ? {
 settings.maxSize = DEFAULT_MAX_SIZE;
 
 // add type
-if ( window.location.pathname.indexOf( '/preview' ) === 0 ) {
+if ( window.location.pathname.includes( '/preview/' ) ) {
     settings.type = 'preview';
-} else if ( window.location.pathname.indexOf( '/single' ) === 0 ) {
+} else if ( window.location.pathname.includes( '/single/' ) ) {
     settings.type = 'single';
-} else if ( window.location.pathname.indexOf( '/edit' ) === 0 ) {
+} else if ( window.location.pathname.includes( '/edit/' ) ) {
     settings.type = 'edit';
-} else if ( window.location.pathname.indexOf( '/view' ) === 0 ) {
+} else if ( window.location.pathname.includes( '/view/' ) ) {
     settings.type = 'view';
 } else {
     settings.type = 'other';


### PR DESCRIPTION
Closes #195 

This is a less risky approach than #196 which entirely removes this code block.

I manually tried `preview` and `single` prefixes.