### PR TITLE
fixed: enable once protection for Enketo at subpath

### DIFF
--- a/app/controllers/survey-controller.js
+++ b/app/controllers/survey-controller.js
@@ -107,7 +107,7 @@ function single( req, res, next ) {
         iframe: req.iframe
     };
     if ( req.encryptedEnketoId && req.cookies[ req.encryptedEnketoId ] ) {
-        res.redirect( `/thanks?taken=${req.cookies[ req.encryptedEnketoId ]}` );
+        res.redirect( `${req.baseUrl}/thanks?taken=${req.cookies[ req.encryptedEnketoId ]}` );
     } else {
         _renderWebform( req, res, next, options );
     }

--- a/public/js/src/module/controller-webform.js
+++ b/public/js/src/module/controller-webform.js
@@ -313,7 +313,7 @@ function _submitRecord() {
                     $( 'form.or' ).empty();
                     $( 'button#submit-form' ).remove();
                     d.setTime( d.getTime() + age * 1000 );
-                    document.cookie = `${settings.enketoId}=${now.getTime()};path=/single;max-age=${age};expires=${d.toGMTString()};`;
+                    document.cookie = `${settings.enketoId}=${now.getTime()};path=${settings.basePath}/single;max-age=${age};expires=${d.toGMTString()};`;
                 }
                 msg += t( 'alert.submissionsuccess.redirectmsg' );
                 gui.alert( msg, t( 'alert.submissionsuccess.heading' ), level );


### PR DESCRIPTION
Closes #199 

Forgive me, @MartijnR, I looked around for other subpath issues when addressing #195 but didn't spot these. I didn't realize that all that is required to try running as a subpath is to change the config so I hadn't previously tried it locally.

I think the `path` filter on the `once` cookie is a good thing because it means the cookie won't show up in a browser inspector unless a user is at a `single/` path. That makes identifying the cookie and working around it a little bit trickier.

Now I've done the following:
- Tried both `/single` and `/single/once` URLs at a subpath
- Run `grunt eslint`
- Searched across the codebase for `.redirect` and `path=`

I also considered using a relative path for that (`../thanks`) but using the base URL seems more robust. I think it would also be possible to use `config[ 'base path']` but I don't see any advantage.

Out of curiosity, what purpose does the `taken` token serve?