### PR TITLE
changed: added geocoding api

### DIFF
--- a/app/controllers/api-v2-controller.js
+++ b/app/controllers/api-v2-controller.js
@@ -13,6 +13,8 @@ const utils = require( '../lib/utils' );
 const keys = require( '../lib/router-utils' ).idEncryptionKeys;
 const router = express.Router();
 const quotaErrorMessage = 'Forbidden. No quota left';
+const configModel = require( '../models/config-model' );
+const getMapboxResponse = require( '../lib/geocoder/mapbox' );
 // var debug = require( 'debug' )( 'api-controller-v2' );
 
 module.exports = app => {
@@ -27,6 +29,9 @@ router
     } )
     .get( '/version', getVersion )
     .post( '/version', getVersion )
+
+    .get( '/geocoder', getGeocodeResponse )
+
     .all( '*', authCheck )
     .all( '*', _setQuotaUsed )
     .all( '*', _setDefaultsQueryParam )
@@ -427,6 +432,17 @@ function removeInstance( req, res, next ) {
         .catch( next );
 }
 
+function getGeocodeResponse( req, res ){
+    switch( configModel.server.geocoder.provider ){
+        case 'mapbox':
+            getMapboxResponse( req.query, ( response ) => {
+                res.json(  response  );
+            } );
+            break;
+        default:
+            throw new Error( 'Geocoder provider is not configured. Please configure `config.geocoder.provider`' );
+    }
+}
 
 /**
  * @param {module:api-controller~ExpressRequest} req - HTTP request

--- a/app/lib/geocoder/mapbox.js
+++ b/app/lib/geocoder/mapbox.js
@@ -11,6 +11,7 @@ module.exports = function getMapboxResponse( query, callback ) {
         access_token: accessToken,
         proximity: query.$center, // -93.17284130807734,45.070291367515466
         bbox: query.$bbox, // -93.13644718051957,45.05118347242032,-93.17284130807734,45.070291367515466
+        limit: query.$limit,
     } );
 
     return request( url.replace( '{address}', query.address ),
@@ -26,7 +27,7 @@ module.exports = function getMapboxResponse( query, callback ) {
                     features: [],
                 };
             }
-            callback(
+            data = data.features ?
                 data.features.map( f => {
                     return {
                         geometry: f.geometry,
@@ -39,8 +40,8 @@ module.exports = function getMapboxResponse( query, callback ) {
                             accuracy: f.properties.accuracy,
                         }
                     };
-                } )
-            );
+                } ) : { error: data.message };
+            callback( data );
         }
     );
 };

--- a/app/lib/geocoder/mapbox.js
+++ b/app/lib/geocoder/mapbox.js
@@ -1,0 +1,46 @@
+const configModel = require( '../../models/config-model' );
+const request = require( 'request' );
+
+module.exports = function getMapboxResponse( query, callback ) {
+
+    const config = configModel.server.geocoder;
+    let url = config.url || 'https://api.mapbox.com/geocoding/v5/mapbox.places/{address}.json';
+    const accessToken = config.apiKey;
+
+    const params = Object.assign( {}, config.params, {
+        access_token: accessToken,
+        proximity: query.$center, // -93.17284130807734,45.070291367515466
+        bbox: query.$bbox, // -93.13644718051957,45.05118347242032,-93.17284130807734,45.070291367515466
+    } );
+
+    return request( url.replace( '{address}', query.address ),
+        {
+            qs: params
+        },
+        ( error, response, body ) => {
+            let data;
+            try {
+                data = JSON.parse( body );
+            } catch( e ) {
+                data = {
+                    features: [],
+                };
+            }
+            callback(
+                data.features.map( f => {
+                    return {
+                        geometry: f.geometry,
+                        id: f.id,
+                        type: f.type,
+                        properties: {
+                            name: f.place_name,
+                            type: f.place_type.join( ',' ),
+                            score: f.relevance,
+                            accuracy: f.properties.accuracy,
+                        }
+                    };
+                } )
+            );
+        }
+    );
+};


### PR DESCRIPTION
In response to #123 

I created a service on /api/v2/geocoder.

It returns basic geojson with the lat/lon and Metadata from the provider (currently only mapbox)

New providers can be added without major rework. 

Note, additional config needed:

```js

    "geocoder": {
        "provider": "mapbox",
        "url": "https://api.mapbox.com/geocoding/v5/mapbox.places/{address}.json", // optional
        "apiKey": "pk....." // required
    },
```

Let me know your thoughts 