### PR TITLE
Fix/facilitate static resource caching 259

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -19,3 +19,4 @@ This document covers the state of Enketo Express as well as the Enketo libraries
 - Switch to latest official Sass tool (Dart sass but the node version of that).
 - Tests in Enketo Core should be able to run much faster with some work.
 - The events.js module in Enketo Core (used in Enketo Express too) might need a redesign. The API just doesn't look attractive (rewrite affects OpenClinica fork).
+- Expand testing coverage in Enketo Express, and perhaps figure out a better way to test XForms.

--- a/STATE.md
+++ b/STATE.md
@@ -1,0 +1,21 @@
+This document covers the state of Enketo Express as well as the Enketo libraries it is using (Enketo Core, Enketo Transformer).
+
+
+### Where we are
+
+- We have a logically separated set of Enketo libraries to facilitate the development of both hybrid mobile apps and web applications. The extra effort this requires (vs. one repo for everything), is probably worth it. Examples of hybrid mobile apps are Medic Mobile's app and Survey123.
+- We have a relatively new enketo-core widget structure that is easy to extend, test and ensures consistency between widgets.
+- We have a recently developed new XPath evaluator that is blazing fast.
+-
+
+### Where we are going
+
+- Complete the replacement of jQuery with native JS and utility functions in dom-utils.js (in Enketo Core)
+- Removing asynchronous constraint validation (in Enketo Core) and simplify the test specs would be wonderful. It is currently asynchronous to facilitate a need (extension) by Medic Mobile to validate phone numbers with an external service.
+- Rewriting/refactoring very old code in ........,  ....., ... ., .....
+- Simplify enketo-transformer by completely changing the way translations are handled and simply copy the `<itext>` block in the model to be passed to Enketo Core. Translation lookups would be done on the client using XPath (rewriting itext queries to native XPath).
+- The XSL stylesheets in Enketo Transformer could probably be much improved in terms of readability and perhaps performance (after moving itext handling to the client)
+- The node-libxslt library is repeatedly preventing Enketo from adopting the latest node or npm versions, sometimes for years. It would be good if we have the expertise and ability to take over managing that tool. I believe the owner would be open to that.
+- Switch to latest official Sass tool (Dart sass but the node version of that).
+- Tests in Enketo Core should be able to run much faster with some work.
+- The events.js module in Enketo Core (used in Enketo Express too) might need a redesign. The API just doesn't look attractive (rewrite affects OpenClinica fork).

--- a/public/js/src/module/application-cache.js
+++ b/public/js/src/module/application-cache.js
@@ -14,7 +14,7 @@ function init( survey ) {
                     // Registration was successful
                     console.log( 'Offline application service worker registration successful with scope: ', registration.scope );
                     setInterval( () => {
-                        console.log( 'Checking for offlince application cache service worker update' );
+                        console.log( 'Checking for offline application cache service worker update' );
                         registration.update();
                     }, 60 * 60 * 1000 );
 

--- a/public/js/src/module/offline-app-worker-partial.js
+++ b/public/js/src/module/offline-app-worker-partial.js
@@ -12,13 +12,11 @@ self.addEventListener( 'install', event => {
             .then( cache => {
                 console.log( 'Opened cache' );
 
-                return cache.addAll( resources );
+                // To bypass any HTTP caching, always obtain resource from network
+                return cache.addAll( resources.map( resource => new Request( resource, { cache: 'reload' } ) ) );
             } )
             .catch( e => {
                 console.log( 'Service worker install error', e );
-            } )
-            .catch( e => {
-                console.error( 'Error posting service worker install message to client', e );
             } )
     );
 } );
@@ -53,7 +51,8 @@ self.addEventListener( 'fetch', event => {
 
                 // TODO: we have a fallback page we could serve when offline, but tbc if that is actually useful at all
 
-                return fetch( event.request, { credentials: 'same-origin' } )
+                // To bypass any HTTP caching, always obtain resource from network
+                return fetch( event.request, { credentials: 'same-origin', cache: 'reload' } )
                     .then( response => {
                         const isScopedResource = event.request.url.includes( '/x/' );
                         const isTranslation = event.request.url.includes( '/locales/build/' );


### PR DESCRIPTION
See https://github.com/enketo/enketo-express/issues/259

I chose the `{cache: 'reload'}` option from these: https://developer.mozilla.org/en-US/docs/Web/API/Request/cache since refreshing the HTTP Cache (for online-only forms) would seem like a good opportunity that doesn't cost anything.

Offline-capable and online-only forms should have the same performance as before.

This PR opens up the possibility of speeding up online-only forms by using a HTTP cache (not part of this PR).

