### PR TITLE
fixed: HTTP cache implemented in web server could break app caching f…

### DIFF
--- a/public/js/src/module/application-cache.js
+++ b/public/js/src/module/application-cache.js
@@ -14,7 +14,7 @@ function init( survey ) {
                     // Registration was successful
                     console.log( 'Offline application service worker registration successful with scope: ', registration.scope );
                     setInterval( () => {
-                        console.log( 'Checking for offlince application cache service worker update' );
+                        console.log( 'Checking for offline application cache service worker update' );
                         registration.update();
                     }, 60 * 60 * 1000 );
 

--- a/public/js/src/module/offline-app-worker-partial.js
+++ b/public/js/src/module/offline-app-worker-partial.js
@@ -12,13 +12,11 @@ self.addEventListener( 'install', event => {
             .then( cache => {
                 console.log( 'Opened cache' );
 
-                return cache.addAll( resources );
+                // To bypass any HTTP caching, always obtain resource from network
+                return cache.addAll( resources.map( resource => new Request( resource, { cache: 'reload' } ) ) );
             } )
             .catch( e => {
                 console.log( 'Service worker install error', e );
-            } )
-            .catch( e => {
-                console.error( 'Error posting service worker install message to client', e );
             } )
     );
 } );
@@ -53,7 +51,8 @@ self.addEventListener( 'fetch', event => {
 
                 // TODO: we have a fallback page we could serve when offline, but tbc if that is actually useful at all
 
-                return fetch( event.request, { credentials: 'same-origin' } )
+                // To bypass any HTTP caching, always obtain resource from network
+                return fetch( event.request, { credentials: 'same-origin', cache: 'reload' } )
                     .then( response => {
                         const isScopedResource = event.request.url.includes( '/x/' );
                         const isTranslation = event.request.url.includes( '/locales/build/' );


### PR DESCRIPTION
…unctionality, #259

I chose the {cache: 'reload'} option from these: https://developer.mozilla.org/en-US/docs/Web/API/Request/cache since refreshing the HTTP Cache (for online-only forms) would seem like a good opportunity that doesn't cost anything.

Offline-capable and online-only forms should have the same performance as before.

This PR opens up the possibility of speeding up online-only forms by using a HTTP cache (not part of this PR).

Also snuck in the removal of a `.catch()` that cannot catch anything.