### PR TITLE
Support for jr:instance/last-saved endpoint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,8 @@
     },
     "extends": "eslint:recommended",
     "plugins": [
-        "jsdoc"
+        "jsdoc",
+        "unicorn"
     ],
     "parserOptions": {
         "sourceType": "module",
@@ -53,7 +54,8 @@
         "jsdoc/require-returns-check": 1,
         "jsdoc/require-returns-description": 1,
         "jsdoc/require-returns-type": 1,
-        "jsdoc/valid-types": 1
+        "jsdoc/valid-types": 1,
+        "unicorn/expiring-todo-comments": "error"
     }
 }
 

--- a/app/models/record-model.js
+++ b/app/models/record-model.js
@@ -1,0 +1,25 @@
+/**
+ * @typedef {import('../../public/js/src/module/store')} ClientStore
+ */
+
+/**
+ * @typedef EnketoRecord Enketo's Record representation of an Instance
+ * @property { string } enketoId - identifier for the form the record is associated with
+ * @property { string } instanceId - the record's primary key identifier
+ * @property { string } name - a unique name assigned to the record by a user
+ * @property { string } xml - the serialized representation of the record's current state
+ * @property { string } [created] - when the record was created in the store
+ * @property { string } [updated] - when the record was most recently updated in the store
+ * @property { string } [deprecatedId] - deprecated (previous) ID of record
+ * @property { boolean } [draft] - whether the record was saved either as a draft or auto-saved
+ * @property { window.File[] } [files] - any files attached to the record
+ * @see {@link https://getodk.github.io/xforms-spec/#instance}
+ * @see {ClientStore}
+ */
+
+/** Note: currently this module exists to provide a type definition for EnketoRecord
+ * in a place consistent with where other data model types are defined. This export
+ * is only present because an ESM module (if this is treated as one) must import
+ * or export _something_.
+ */
+export {};

--- a/app/models/survey-model.js
+++ b/app/models/survey-model.js
@@ -79,10 +79,10 @@ if ( process.env.NODE_ENV === 'test' ) {
  * @property { string } [returnUrl]
  * @property { string } [xslHash]
  * @description
- *   `SureveyObject` is Enketo's internal representation of an XForm, with some
+ *   `SurveyObject` is Enketo's internal representation of an XForm, with some
  *   additional properties representing resolved/deserialized external data.
  *   This type definition captures the current state of "what is"—i.e. the full
- *   known set of properties which may be added to a `SureveyObject` through
+ *   known set of properties which may be added to a `SurveyObject` through
  *   several data flow paths throught enketo-express. Some related resources,
  *   notably those describing instances, are only populated in paths specific
  *   to the interaction between a `SurveyObject` and those resources.

--- a/app/models/survey-model.js
+++ b/app/models/survey-model.js
@@ -35,10 +35,6 @@ if ( process.env.NODE_ENV === 'test' ) {
  */
 
 /**
- * @typedef {import('../../public/js/src/module/store').Record} InstanceRecord
- */
-
-/**
  * @typedef SurveyCredentials
  * @property { string } user
  * @property { string } pass
@@ -66,8 +62,8 @@ if ( process.env.NODE_ENV === 'test' ) {
  * @property { Array<string | Document> } [externalData]
  * @property { string } [form]
  * @property { string } [formHash]
- * @property { InstanceRecord } [instance]
- * @property { string | object } [instanceAttachments]
+ * @property { EnketoRecord } [instance]
+ * @property { Array<string | object> } [instanceAttachments]
  * @property { string } [instanceId]
  * @property { EnketoRecord } [lastSavedRecord]
  * @property { Record<string, unknown> } [languageMap]
@@ -76,6 +72,14 @@ if ( process.env.NODE_ENV === 'test' ) {
  * @property { EnketoTransformerPreprocess } [preprocess]
  * @property { string } [returnUrl]
  * @property { string } [xslHash]
+ * @description
+ *   `SureveyObject` is Enketo's internal representation of an XForm, with some
+ *   additional properties representing resolved/deserialized external data.
+ *   This type definition captures the current state of "what is"—i.e. the full
+ *   known set of properties which may be added to a `SureveyObject` through
+ *   several data flow paths throught enketo-express. Some related resources,
+ *   notably those describing instances, are only populated in paths specific
+ *   to the interaction between a `SurveyObject` and those resources.
  */
 
 /**

--- a/app/models/survey-model.js
+++ b/app/models/survey-model.js
@@ -42,7 +42,10 @@ if ( process.env.NODE_ENV === 'test' ) {
  */
 
 /**
- * @typedef SurveyExternalData
+ * @typedef SurveyExternalData Note: a survey's `externalData` may include data from
+ *   that survey's {@link https://getodk.github.io/xforms-spec/#virtual-endpoints last-saved virtual endpoint}
+ *   when referenced in the survey's model. If the survey does not yet have a last-saved
+ *   record, those references will be populated by default with the survey's model.
  * @property { string } id
  * @property { string } src
  * @property { string | Document } xml

--- a/app/models/survey-model.js
+++ b/app/models/survey-model.js
@@ -19,13 +19,63 @@ if ( process.env.NODE_ENV === 'test' ) {
 }
 
 /**
+ * @typedef {import('./account-model').AccountObj} AccountObj
+ */
+
+/**
+ * @typedef {import('./account-model').EnketoRecord} EnketoRecord
+ */
+
+/**
+ * @typedef {typeof import('libxmljs').Document} XMLJSDocument
+ */
+
+/**
+ * @typedef {(doc: XMLJSDocument) => XMLJSDocument} EnketoTransformerPreprocess
+ */
+
+/**
+ * @typedef {import('../../public/js/src/module/store').Record} InstanceRecord
+ */
+
+/**
+ * @typedef SurveyCredentials
+ * @property { string } user
+ * @property { string } pass
+ * @property { string } bearer
+ */
+
+/**
+ * @typedef SurveyInfo
+ * @property { string } downloadUrl
+ * @property { string } manifestUrl
+ */
+
+/**
  * @typedef SurveyObject
  * @property { string } openRosaServer
  * @property { string } openRosaId
  * @property { string } enketoId
  * @property { string } theme
- * @property { object } info
- * @property { string } info.hash
+ * @property { SurveyInfo } [info]
+ * @property { AccountObj } [account]
+ * @property { boolean | 'true' | 'false' } [active]
+ * @property { string } [cookie]
+ * @property { SurveyCredentials } [credentials]
+ * @property { string } [customParam]
+ * @property { Array<string | Document> } [externalData]
+ * @property { string } [form]
+ * @property { string } [formHash]
+ * @property { InstanceRecord } [instance]
+ * @property { string | object } [instanceAttachments]
+ * @property { string } [instanceId]
+ * @property { EnketoRecord } [lastSavedRecord]
+ * @property { Record<string, unknown> } [languageMap]
+ * @property { Record<string, unknown> } [manifest]
+ * @property { string } [model]
+ * @property { EnketoTransformerPreprocess } [preprocess]
+ * @property { string } [returnUrl]
+ * @property { string } [xslHash]
  */
 
 /**
@@ -35,7 +85,7 @@ if ( process.env.NODE_ENV === 'test' ) {
  * @name get
  * @function
  * @param { string } id - Survey ID
- * @return {Promise<Error|SurveyObject>} Promise that resolves with a survey object
+ * @return {Promise<SurveyObject>} Promise that resolves with a survey object
  */
 function getSurvey( id ) {
     return new Promise( ( resolve, reject ) => {

--- a/app/models/survey-model.js
+++ b/app/models/survey-model.js
@@ -27,11 +27,13 @@ if ( process.env.NODE_ENV === 'test' ) {
  */
 
 /**
- * @typedef {typeof import('libxmljs').Document} XMLJSDocument
+ * @typedef {import('libxmljs').Document} XMLJSDocument
  */
 
 /**
- * @typedef {(doc: XMLJSDocument) => XMLJSDocument} EnketoTransformerPreprocess
+ * @typedef {Function} EnketoTransformerPreprocess
+ * @param {XMLJSDocument} doc
+ * @return {XMLJSDocument}
  */
 
 /**

--- a/app/models/survey-model.js
+++ b/app/models/survey-model.js
@@ -42,6 +42,12 @@ if ( process.env.NODE_ENV === 'test' ) {
  */
 
 /**
+ * @typedef SurveyExternalData
+ * @property { string } id
+ * @property { string } src
+ * @property { string | Document } xml
+ */
+/**
  * @typedef SurveyInfo
  * @property { string } downloadUrl
  * @property { string } manifestUrl
@@ -59,7 +65,7 @@ if ( process.env.NODE_ENV === 'test' ) {
  * @property { string } [cookie]
  * @property { SurveyCredentials } [credentials]
  * @property { string } [customParam]
- * @property { Array<string | Document> } [externalData]
+ * @property { SurveyExternalData[] } [externalData]
  * @property { string } [form]
  * @property { string } [formHash]
  * @property { EnketoRecord } [instance]

--- a/jsdoc.config.js
+++ b/jsdoc.config.js
@@ -17,7 +17,7 @@ module.exports = {
         readme: 'README.md',
         template: 'node_modules/docdash'
     },
-    plugins: [ 'plugins/markdown' ],
+    plugins: [ 'jsdoc-ts-utils', 'plugins/markdown' ],
     source: {
         include: [
             'app/',
@@ -75,5 +75,12 @@ module.exports = {
             'Mixins',
             'Interfaces'
         ]
-    }
+    },
+    tsUtils: {
+        /**
+         * We may actually want to enable this, but it was a surprisng default.
+         * @see {@link https://github.com/homer0/jsdoc-ts-utils#configuration}
+         */
+        typeScriptUtilityTypes: false,
+    },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6855,6 +6855,15 @@
                 }
             }
         },
+        "jsdoc-ts-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/jsdoc-ts-utils/-/jsdoc-ts-utils-2.0.0.tgz",
+            "integrity": "sha512-xTwLOGJ7K4xs1ZL+YHTl5cYHO2idNgY0FzRJPp/WCw7t61L2fU8odK5Hteos0B+1sEN+ZSLceoBfXXJnVJNokQ==",
+            "dev": true,
+            "requires": {
+                "jsdoc": "^3.6.6"
+            }
+        },
         "jsdoctypeparser": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3839,6 +3839,59 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "es-abstract": {
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+            "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.2",
+                "is-callable": "^1.2.3",
+                "is-negative-zero": "^2.0.1",
+                "is-regex": "^1.1.3",
+                "is-string": "^1.0.6",
+                "object-inspect": "^1.10.3",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.2",
+                "string.prototype.trimend": "^1.0.4",
+                "string.prototype.trimstart": "^1.0.4",
+                "unbox-primitive": "^1.0.1"
+            },
+            "dependencies": {
+                "has-symbols": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+                    "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+                    "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-symbols": "^1.0.2"
+                    }
+                }
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
         "es6-error": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
@@ -5618,6 +5671,12 @@
                 "ansi-regex": "^2.0.0"
             }
         },
+        "has-bigints": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+            "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+            "dev": true
+        },
         "has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -6071,6 +6130,12 @@
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
         },
+        "is-bigint": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+            "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
+            "dev": true
+        },
         "is-binary-path": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -6078,6 +6143,15 @@
             "dev": true,
             "requires": {
                 "binary-extensions": "^1.0.0"
+            }
+        },
+        "is-boolean-object": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+            "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2"
             }
         },
         "is-buffer": {
@@ -6094,6 +6168,12 @@
             "requires": {
                 "builtin-modules": "^3.0.0"
             }
+        },
+        "is-callable": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+            "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+            "dev": true
         },
         "is-ci": {
             "version": "1.2.1",
@@ -6131,6 +6211,12 @@
                     }
                 }
             }
+        },
+        "is-date-object": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+            "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
+            "dev": true
         },
         "is-descriptor": {
             "version": "0.1.6",
@@ -6220,6 +6306,12 @@
             "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
             "dev": true
         },
+        "is-negative-zero": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+            "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+            "dev": true
+        },
         "is-npm": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -6245,6 +6337,12 @@
                     }
                 }
             }
+        },
+        "is-number-object": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+            "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
+            "dev": true
         },
         "is-obj": {
             "version": "1.0.1",
@@ -6327,6 +6425,29 @@
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
             "dev": true
+        },
+        "is-string": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+            "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
+            "dev": true
+        },
+        "is-symbol": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.2"
+            },
+            "dependencies": {
+                "has-symbols": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+                    "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+                    "dev": true
+                }
+            }
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -9062,6 +9183,12 @@
                 }
             }
         },
+        "object-inspect": {
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+            "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+            "dev": true
+        },
         "object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -9097,6 +9224,18 @@
                 "array-slice": "^1.0.0",
                 "for-own": "^1.0.0",
                 "isobject": "^3.0.0"
+            }
+        },
+        "object.fromentries": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.4.tgz",
+            "integrity": "sha512-EsFBshs5RUUpQEY1D4q/m59kMfz4YJvxuNCJcv/jWwOJr34EaVnG11ZrZa0UHB3wnzV1wx8m58T4hQL8IuNXlQ==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.18.0-next.2",
+                "has": "^1.0.3"
             }
         },
         "object.map": {
@@ -11207,6 +11346,26 @@
                 "strip-ansi": "^3.0.0"
             }
         },
+        "string.prototype.trimend": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+            "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            }
+        },
+        "string.prototype.trimstart": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+            "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            }
+        },
         "string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -11930,6 +12089,26 @@
                 "random-bytes": "~1.0.0"
             }
         },
+        "unbox-primitive": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+            "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has-bigints": "^1.0.1",
+                "has-symbols": "^1.0.2",
+                "which-boxed-primitive": "^1.0.2"
+            },
+            "dependencies": {
+                "has-symbols": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+                    "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+                    "dev": true
+                }
+            }
+        },
         "unbzip2-stream": {
             "version": "1.4.3",
             "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
@@ -12389,6 +12568,19 @@
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "requires": {
                 "isexe": "^2.0.0"
+            }
+        },
+        "which-boxed-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+            "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+            "dev": true,
+            "requires": {
+                "is-bigint": "^1.0.1",
+                "is-boolean-object": "^1.1.0",
+                "is-number-object": "^1.0.4",
+                "is-string": "^1.0.5",
+                "is-symbol": "^1.0.3"
             }
         },
         "which-module": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,246 @@
                 "@babel/highlight": "^7.12.13"
             }
         },
+        "@babel/compat-data": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.5.tgz",
+            "integrity": "sha512-kixrYn4JwfAVPa0f2yfzc2AWti6WRRyO3XjWW5PJAvtE11qhSayrrcrEnee05KAtNaPC+EwehE8Qt1UedEVB8w==",
+            "dev": true
+        },
+        "@babel/core": {
+            "version": "7.14.6",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
+            "integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.14.5",
+                "@babel/generator": "^7.14.5",
+                "@babel/helper-compilation-targets": "^7.14.5",
+                "@babel/helper-module-transforms": "^7.14.5",
+                "@babel/helpers": "^7.14.6",
+                "@babel/parser": "^7.14.6",
+                "@babel/template": "^7.14.5",
+                "@babel/traverse": "^7.14.5",
+                "@babel/types": "^7.14.5",
+                "convert-source-map": "^1.7.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.1.2",
+                "semver": "^6.3.0",
+                "source-map": "^0.5.0"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+                    "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.14.5"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
+                    "integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5",
+                        "jsesc": "^2.5.1",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+                    "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.14.5",
+                        "@babel/template": "^7.14.5",
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+                    "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+                    "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-validator-identifier": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+                    "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+                    "dev": true
+                },
+                "@babel/highlight": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+                    "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.14.6",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.6.tgz",
+                    "integrity": "sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+                    "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.14.5",
+                        "@babel/parser": "^7.14.5",
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.5.tgz",
+                    "integrity": "sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.14.5",
+                        "@babel/generator": "^7.14.5",
+                        "@babel/helper-function-name": "^7.14.5",
+                        "@babel/helper-hoist-variables": "^7.14.5",
+                        "@babel/helper-split-export-declaration": "^7.14.5",
+                        "@babel/parser": "^7.14.5",
+                        "@babel/types": "^7.14.5",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+                    "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                    "dev": true
+                },
+                "globals": {
+                    "version": "11.12.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+                    "dev": true
+                },
+                "jsesc": {
+                    "version": "2.5.2",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/eslint-parser": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.14.5.tgz",
+            "integrity": "sha512-20BlOHuGf3UXS7z1QPyllM9Gz8SEgcp/UcKeUmdHIFZO6HF1n+3KaLpeyfwWvjY/Os/ynPX3k8qXE/nZ5dw/0g==",
+            "dev": true,
+            "requires": {
+                "eslint-scope": "^5.1.1",
+                "eslint-visitor-keys": "^2.1.0",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
         "@babel/generator": {
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.13.tgz",
@@ -28,6 +268,26 @@
                     "version": "2.5.2",
                     "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
                     "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-compilation-targets": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
+            "integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
+            "dev": true,
+            "requires": {
+                "@babel/compat-data": "^7.14.5",
+                "@babel/helper-validator-option": "^7.14.5",
+                "browserslist": "^4.16.6",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
                     "dev": true
                 }
             }
@@ -52,6 +312,529 @@
                 "@babel/types": "^7.12.13"
             }
         },
+        "@babel/helper-hoist-variables": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+            "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.14.5"
+            },
+            "dependencies": {
+                "@babel/helper-validator-identifier": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+                    "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+                    "dev": true
+                },
+                "@babel/types": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+                    "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/helper-member-expression-to-functions": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.5.tgz",
+            "integrity": "sha512-UxUeEYPrqH1Q/k0yRku1JE7dyfyehNwT6SVkMHvYvPDv4+uu627VXBckVj891BO8ruKBkiDoGnZf4qPDD8abDQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.14.5"
+            },
+            "dependencies": {
+                "@babel/helper-validator-identifier": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+                    "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+                    "dev": true
+                },
+                "@babel/types": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+                    "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/helper-module-imports": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+            "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.14.5"
+            },
+            "dependencies": {
+                "@babel/helper-validator-identifier": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+                    "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+                    "dev": true
+                },
+                "@babel/types": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+                    "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/helper-module-transforms": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
+            "integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.14.5",
+                "@babel/helper-replace-supers": "^7.14.5",
+                "@babel/helper-simple-access": "^7.14.5",
+                "@babel/helper-split-export-declaration": "^7.14.5",
+                "@babel/helper-validator-identifier": "^7.14.5",
+                "@babel/template": "^7.14.5",
+                "@babel/traverse": "^7.14.5",
+                "@babel/types": "^7.14.5"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+                    "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.14.5"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
+                    "integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5",
+                        "jsesc": "^2.5.1",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+                    "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.14.5",
+                        "@babel/template": "^7.14.5",
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+                    "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+                    "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-validator-identifier": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+                    "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+                    "dev": true
+                },
+                "@babel/highlight": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+                    "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.14.6",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.6.tgz",
+                    "integrity": "sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+                    "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.14.5",
+                        "@babel/parser": "^7.14.5",
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.5.tgz",
+                    "integrity": "sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.14.5",
+                        "@babel/generator": "^7.14.5",
+                        "@babel/helper-function-name": "^7.14.5",
+                        "@babel/helper-hoist-variables": "^7.14.5",
+                        "@babel/helper-split-export-declaration": "^7.14.5",
+                        "@babel/parser": "^7.14.5",
+                        "@babel/types": "^7.14.5",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+                    "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                    "dev": true
+                },
+                "globals": {
+                    "version": "11.12.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+                    "dev": true
+                },
+                "jsesc": {
+                    "version": "2.5.2",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/helper-optimise-call-expression": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+            "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.14.5"
+            },
+            "dependencies": {
+                "@babel/helper-validator-identifier": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+                    "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+                    "dev": true
+                },
+                "@babel/types": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+                    "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/helper-replace-supers": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
+            "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-member-expression-to-functions": "^7.14.5",
+                "@babel/helper-optimise-call-expression": "^7.14.5",
+                "@babel/traverse": "^7.14.5",
+                "@babel/types": "^7.14.5"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+                    "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.14.5"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
+                    "integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5",
+                        "jsesc": "^2.5.1",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+                    "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.14.5",
+                        "@babel/template": "^7.14.5",
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+                    "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+                    "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-validator-identifier": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+                    "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+                    "dev": true
+                },
+                "@babel/highlight": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+                    "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.14.6",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.6.tgz",
+                    "integrity": "sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+                    "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.14.5",
+                        "@babel/parser": "^7.14.5",
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.5.tgz",
+                    "integrity": "sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.14.5",
+                        "@babel/generator": "^7.14.5",
+                        "@babel/helper-function-name": "^7.14.5",
+                        "@babel/helper-hoist-variables": "^7.14.5",
+                        "@babel/helper-split-export-declaration": "^7.14.5",
+                        "@babel/parser": "^7.14.5",
+                        "@babel/types": "^7.14.5",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+                    "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                    "dev": true
+                },
+                "globals": {
+                    "version": "11.12.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+                    "dev": true
+                },
+                "jsesc": {
+                    "version": "2.5.2",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/helper-simple-access": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
+            "integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.14.5"
+            },
+            "dependencies": {
+                "@babel/helper-validator-identifier": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+                    "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+                    "dev": true
+                },
+                "@babel/types": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+                    "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
+            }
+        },
         "@babel/helper-split-export-declaration": {
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
@@ -65,6 +848,203 @@
             "version": "7.12.11",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
             "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+        },
+        "@babel/helper-validator-option": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+            "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+            "dev": true
+        },
+        "@babel/helpers": {
+            "version": "7.14.6",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
+            "integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.14.5",
+                "@babel/traverse": "^7.14.5",
+                "@babel/types": "^7.14.5"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+                    "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.14.5"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
+                    "integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5",
+                        "jsesc": "^2.5.1",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+                    "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.14.5",
+                        "@babel/template": "^7.14.5",
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+                    "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+                    "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-validator-identifier": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+                    "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+                    "dev": true
+                },
+                "@babel/highlight": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+                    "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.14.6",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.6.tgz",
+                    "integrity": "sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+                    "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.14.5",
+                        "@babel/parser": "^7.14.5",
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.5.tgz",
+                    "integrity": "sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.14.5",
+                        "@babel/generator": "^7.14.5",
+                        "@babel/helper-function-name": "^7.14.5",
+                        "@babel/helper-hoist-variables": "^7.14.5",
+                        "@babel/helper-split-export-declaration": "^7.14.5",
+                        "@babel/parser": "^7.14.5",
+                        "@babel/types": "^7.14.5",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+                    "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                    "dev": true
+                },
+                "globals": {
+                    "version": "11.12.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+                    "dev": true
+                },
+                "jsesc": {
+                    "version": "2.5.2",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
         },
         "@babel/highlight": {
             "version": "7.12.13",
@@ -297,6 +1277,12 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
             "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ=="
         },
+        "@types/normalize-package-data": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+            "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+            "dev": true
+        },
         "@types/resolve": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
@@ -324,6 +1310,12 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+        },
+        "abortcontroller-polyfill": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
+            "integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q==",
+            "dev": true
         },
         "abstract-leveldown": {
             "version": "0.12.4",
@@ -1332,6 +2324,19 @@
                 "through": "^2.3.7"
             }
         },
+        "browserslist": {
+            "version": "4.16.6",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+            "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+            "dev": true,
+            "requires": {
+                "caniuse-lite": "^1.0.30001219",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.723",
+                "escalade": "^3.1.1",
+                "node-releases": "^1.1.71"
+            }
+        },
         "buffer": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -1460,6 +2465,12 @@
                 "camelcase": "^2.0.0",
                 "map-obj": "^1.0.0"
             }
+        },
+        "caniuse-lite": {
+            "version": "1.0.30001237",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz",
+            "integrity": "sha512-pDHgRndit6p1NR2GhzMbQ6CkRrp4VKuSsqbcLeOQppYPKOYkKT/6ZvZDvKJUqcmtyWIAHuZq3SVS2vc1egCZzw==",
+            "dev": true
         },
         "capture-stack-trace": {
             "version": "1.0.1",
@@ -1674,6 +2685,15 @@
             "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
             "integrity": "sha1-k1vC39lFiodrJ5YXUUY4vKqWSi4="
         },
+        "clean-regexp": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
+            "integrity": "sha1-jffHquUf02h06PjQW5GAvBGj/tc=",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^1.0.5"
+            }
+        },
         "cli-boxes": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
@@ -1775,6 +2795,12 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "colorette": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+            "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+            "dev": true
         },
         "colors": {
             "version": "1.1.2",
@@ -2596,6 +3622,12 @@
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
             "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
         },
+        "electron-to-chromium": {
+            "version": "1.3.752",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.752.tgz",
+            "integrity": "sha512-2Tg+7jSl3oPxgsBsWKh5H83QazTkmWG/cnNwJplmyZc7KcN61+I10oUgaXSVk/NwfvN3BdkKDR4FYuRBQQ2v0A==",
+            "dev": true
+        },
         "elliptic": {
             "version": "6.5.4",
             "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
@@ -3081,6 +4113,154 @@
                 }
             }
         },
+        "eslint-plugin-unicorn": {
+            "version": "33.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-33.0.1.tgz",
+            "integrity": "sha512-VxX/L/9DUEyB3D0v00185LrgsB5/fBwkgA4IC7ehHRu5hFSgA6VecmdpFybhsr4GQ/Y1iyXMHf6q+JKvcR2MwA==",
+            "dev": true,
+            "requires": {
+                "ci-info": "^3.1.1",
+                "clean-regexp": "^1.0.0",
+                "eslint-template-visitor": "^2.3.2",
+                "eslint-utils": "^3.0.0",
+                "import-modules": "^2.1.0",
+                "is-builtin-module": "^3.1.0",
+                "lodash": "^4.17.21",
+                "pluralize": "^8.0.0",
+                "read-pkg-up": "^7.0.1",
+                "regexp-tree": "^0.1.23",
+                "reserved-words": "^0.1.2",
+                "safe-regex": "^2.1.1",
+                "semver": "^7.3.5"
+            },
+            "dependencies": {
+                "ci-info": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
+                    "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+                    "dev": true
+                },
+                "eslint-utils": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+                    "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+                    "dev": true,
+                    "requires": {
+                        "eslint-visitor-keys": "^2.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "parse-json": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+                    "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "error-ex": "^1.3.1",
+                        "json-parse-even-better-errors": "^2.3.0",
+                        "lines-and-columns": "^1.1.6"
+                    }
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+                    "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/normalize-package-data": "^2.4.0",
+                        "normalize-package-data": "^2.5.0",
+                        "parse-json": "^5.0.0",
+                        "type-fest": "^0.6.0"
+                    },
+                    "dependencies": {
+                        "type-fest": {
+                            "version": "0.6.0",
+                            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+                            "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+                            "dev": true
+                        }
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+                    "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^4.1.0",
+                        "read-pkg": "^5.2.0",
+                        "type-fest": "^0.8.1"
+                    }
+                },
+                "safe-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+                    "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+                    "dev": true,
+                    "requires": {
+                        "regexp-tree": "~0.1.1"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.5",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+                    "dev": true
+                }
+            }
+        },
         "eslint-scope": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -3089,6 +4269,19 @@
             "requires": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
+            }
+        },
+        "eslint-template-visitor": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/eslint-template-visitor/-/eslint-template-visitor-2.3.2.tgz",
+            "integrity": "sha512-3ydhqFpuV7x1M9EK52BPNj6V0Kwu0KKkcIAfpUhwHbR8ocRln/oUHgfxQupY8O1h4Qv/POHDumb/BwwNfxbtnA==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.12.16",
+                "@babel/eslint-parser": "^7.12.16",
+                "eslint-visitor-keys": "^2.0.0",
+                "esquery": "^1.3.1",
+                "multimap": "^1.1.0"
             }
         },
         "eslint-utils": {
@@ -3905,6 +5098,12 @@
             "requires": {
                 "globule": "^1.0.0"
             }
+        },
+        "gensync": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true
         },
         "get-caller-file": {
             "version": "2.0.5",
@@ -4771,6 +5970,12 @@
             "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
             "dev": true
         },
+        "import-modules": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.1.0.tgz",
+            "integrity": "sha512-8HEWcnkbGpovH9yInoisxaSoIg9Brbul+Ju3Kqe2UsYDUBJD/iQjSgEj0zPcTDPKfPp2fs5xlv1i+JSye/m1/A==",
+            "dev": true
+        },
         "imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -4880,6 +6085,15 @@
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
+        },
+        "is-builtin-module": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
+            "integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
+            "dev": true,
+            "requires": {
+                "builtin-modules": "^3.0.0"
+            }
         },
         "is-ci": {
             "version": "1.2.1",
@@ -5537,6 +6751,12 @@
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
             "dev": true
         },
+        "json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true
+        },
         "json-schema": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -5557,6 +6777,15 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "json5": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+            "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.5"
+            }
         },
         "jsonfile": {
             "version": "4.0.0",
@@ -6412,6 +7641,12 @@
                 }
             }
         },
+        "lines-and-columns": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+            "dev": true
+        },
         "linkify-it": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
@@ -7193,6 +8428,12 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
+        "multimap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz",
+            "integrity": "sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==",
+            "dev": true
+        },
         "multimatch": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
@@ -7465,6 +8706,12 @@
                     }
                 }
             }
+        },
+        "node-releases": {
+            "version": "1.1.73",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
+            "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+            "dev": true
         },
         "node-sass": {
             "version": "5.0.0",
@@ -8232,6 +9479,12 @@
             "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
             "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY="
         },
+        "pluralize": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+            "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+            "dev": true
+        },
         "posix-character-classes": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -8783,6 +10036,12 @@
                 "safe-regex": "^1.1.0"
             }
         },
+        "regexp-tree": {
+            "version": "0.1.23",
+            "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.23.tgz",
+            "integrity": "sha512-+7HWfb4Bvu8Rs2eQTUIpX9I/PlQkYOuTNbRpKLJlQpSgwSkzFYh+pUj0gtvglnOZLKB6YgnIgRuJ2/IlpL48qw==",
+            "dev": true
+        },
         "regexpp": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
@@ -8955,6 +10214,12 @@
             "requires": {
                 "lodash": "^4.17.14"
             }
+        },
+        "reserved-words": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
+            "integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=",
+            "dev": true
         },
         "resolve": {
             "version": "1.19.0",

--- a/package.json
+++ b/package.json
@@ -130,5 +130,9 @@
         "public/js/src/enketo-webform-edit.js",
         "public/js/src/enketo-webform-view.js",
         "public/js/src/enketo-offline-fallback.js"
-    ]
+    ],
+    "//": "While CI runs Node v12.21.0, v12.18.4 is currently the latest version which is able to run the full test suite without crashing",
+    "volta": {
+        "node": "12.18.4"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
         "karma-sinon-chai": "^2.0.2",
         "mocha": "^8.4.0",
         "nock": "^13.1.0",
+        "object.fromentries": "^2.0.4",
         "rimraf": "^3.0.2",
         "sinon": "^9.2.4",
         "sinon-chai": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -87,10 +87,12 @@
         "xml2js": "^0.4.23"
     },
     "devDependencies": {
+        "abortcontroller-polyfill": "^1.7.3",
         "chai": "^4.3.4",
         "chai-as-promised": "^7.1.1",
         "docdash": "^1.2.0",
         "eslint-plugin-jsdoc": "^32.3.4",
+        "eslint-plugin-unicorn": "^33.0.1",
         "grunt-concurrent": "^3.0.0",
         "grunt-contrib-watch": "^1.1.0",
         "grunt-eslint": "^23.0.0",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
         "istanbul": "^0.4.5",
         "istanbul-reporter-shield-badge": "^1.2.1",
         "jsdoc": "^3.6.7",
+        "jsdoc-ts-utils": "^2.0.0",
         "karma": "^6.3.3",
         "karma-chrome-launcher": "^3.1.0",
         "karma-coverage": "^1.1.2",

--- a/public/js/src/enketo-webform-edit.js
+++ b/public/js/src/enketo-webform-edit.js
@@ -66,6 +66,7 @@ function _init( formParts ) {
         instanceStr: formParts.instance,
         external: formParts.externalData,
         instanceAttachments: formParts.instanceAttachments,
+        isEditing: true,
     } )
         .then( form => {
             formParts.languages = form.languages;

--- a/public/js/src/enketo-webform.js
+++ b/public/js/src/enketo-webform.js
@@ -43,8 +43,9 @@ if ( settings.offline ) {
         .catch( _showErrorOrAuthenticate );
 } else {
     console.log( 'App in online-only mode.' );
-    initTranslator( survey )
-        .then( connection.getFormParts )
+    store.init()
+        .then( () => initTranslator( survey ) )
+        .then( formCache.init )
         .then( _swapTheme )
         .then( _addBranding )
         .then ( connection.getMaximumSubmissionSize )
@@ -202,7 +203,7 @@ function _init( formParts ) {
     } )
         .then( form => {
             formParts.languages = form.languages;
-            formParts.htmlView = formEl;
+
             document.querySelector( 'head>title' ).textContent = utils.getTitleFromFormStr( formParts.form );
             if ( settings.print ) {
                 gui.applyPrintStyle();
@@ -210,6 +211,6 @@ function _init( formParts ) {
             // after widgets have been initialized, localize all data-i18n elements
             localize( formEl );
 
-            return  formParts;
+            return formParts;
         } );
 }

--- a/public/js/src/module/connection.js
+++ b/public/js/src/module/connection.js
@@ -355,6 +355,8 @@ function getMaximumSubmissionSize( survey ) {
  * @return { Promise<Survey> } a Promise that resolves with a form parts object
  */
 function getFormParts( props ) {
+    const isEditing = props.instanceId != null;
+
     /** @type {Survey} */
     let survey;
 
@@ -381,7 +383,9 @@ function getFormParts( props ) {
                 survey = encryptor.setEncryptionEnabled( survey );
             }
 
-            return formCache.getLastSavedRecord( props.enketoId );
+            if ( !isEditing ) {
+                return formCache.getLastSavedRecord( props.enketoId );
+            }
         } )
         .then( lastSaved => {
             lastSavedRecord = lastSaved;

--- a/public/js/src/module/connection.js
+++ b/public/js/src/module/connection.js
@@ -455,6 +455,9 @@ function _encodeFormData( data ){
 }
 
 /**
+ * Gets a survey's last-saved record data as an `XMLDocument`, defaulting to
+ * the survey's model when no last-saved record exists.
+ *
  * @param {Document} model
  * @param {EnketoRecord} [lastSavedRecord]
  * @return {XMLDocument}

--- a/public/js/src/module/controller-webform.js
+++ b/public/js/src/module/controller-webform.js
@@ -425,7 +425,7 @@ function _saveRecord( draft = true, recordName, confirmed, errorMsg ) {
             // Save the record, determine the save method
             const saveMethod = form.recordName ? 'update' : 'set';
 
-            return records[ saveMethod ]( record );
+            return records.save( saveMethod, record );
         } )
         .then( () => {
 

--- a/public/js/src/module/controller-webform.js
+++ b/public/js/src/module/controller-webform.js
@@ -14,13 +14,34 @@ import records from './records-queue';
 import $ from 'jquery';
 import encryptor from './encryptor';
 
+/** @type {Form} */
 let form;
+
 let formData;
 let formprogress;
 const formOptions = {
     printRelevantOnly: settings.printRelevantOnly,
 };
 
+/**
+ * @typedef InstanceAttachment
+ * @property {string} filename
+ */
+
+/**
+ * @typedef ControllerWebformInitData
+ * @property {string} modelStr
+ * @property {string} instanceStr
+ * @property {Document[]} external
+ * @property {InstanceAttachment[]} [instanceAttachments]
+ */
+
+/**
+ * @param {Element} formEl
+ * @param {ControllerWebformInitData} data
+ * @param {string[]} [loadErrors]
+ * @return {Promise<Form>}
+ */
 function init( formEl, data, loadErrors = [] ) {
     formData = data;
 

--- a/public/js/src/module/encryptor.js
+++ b/public/js/src/module/encryptor.js
@@ -6,6 +6,11 @@
  **********************************************************************************************/
 import forge from 'node-forge';
 import utils from './utils';
+
+/**
+ * @typedef {import('./account-model').EnketoRecord} EnketoRecord
+ */
+
 const SYMMETRIC_ALGORITHM = 'AES-CFB'; // JAVA: "AES/CFB/PKCS5Padding"
 const ASYMMETRIC_ALGORITHM = 'RSA-OAEP'; // JAVA: "RSA/NONE/OAEPWithSHA256AndMGF1Padding"
 const ASYMMETRIC_OPTIONS = {
@@ -23,6 +28,12 @@ function isSupported() {
         new ArrayBuffer( 8 ).byteLength === 8 &&
         typeof Uint8Array !== 'undefined' &&
         new Uint8Array( 8 ).length === 8;
+}
+
+const isEncryptedSymbol = Symbol( 'isEncrypted' );
+
+function isEncrypted( record ) {
+    return Boolean( record[isEncryptedSymbol] );
 }
 
 /**
@@ -64,6 +75,14 @@ function encryptRecord( form, record ) {
             // overwrite record properties so it can be process as a regular submission
             record.xml = manifest.getXmlStr();
             record.files = blobs;
+
+            Object.defineProperty( record, isEncryptedSymbol, {
+                configurable: false,
+                enumerable: false,
+                get() {
+                    return true;
+                },
+            } );
 
             return record;
         } );
@@ -237,7 +256,8 @@ function Manifest( formId, formVersion ) {
 }
 
 export default {
+    isEncrypted,
     isSupported,
     encryptRecord,
-    Seed
+    Seed,
 };

--- a/public/js/src/module/encryptor.js
+++ b/public/js/src/module/encryptor.js
@@ -44,6 +44,14 @@ function isEncryptionEnabled( survey ) {
     return Boolean( survey[isEncryptionEnabledSymbol] );
 }
 
+/**
+ * Converts an encryption-enabled survey's private `isEncryptionEnabledSymbol`
+ * property to a serializable string property.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types}
+ * @param {Survey} survey
+ * @return {Survey}
+ */
 function serializeEncryptedSurvey( survey ) {
     if ( isEncryptionEnabled( survey ) ) {
         return Object.assign( {}, survey, {
@@ -54,6 +62,14 @@ function serializeEncryptedSurvey( survey ) {
     return survey;
 }
 
+/**
+ * Restores a serialized survey's encryption-enabled state by converting its
+ * `isEncryptionEnabled` property to the private `isEncryptionEnabledSymbol`.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types}
+ * @param {Survey} survey
+ * @return {Survey}
+ */
 function deserializeEncryptedSurvey( survey ) {
     if ( survey.isEncryptionEnabled ) {
         let result = Object.assign( {}, survey );

--- a/public/js/src/module/form-cache.js
+++ b/public/js/src/module/form-cache.js
@@ -7,6 +7,7 @@ import events from './event';
 import settings from './settings';
 import connection from './connection';
 import assign from 'lodash/assign';
+import encryptor from './encryptor';
 
 /**
  * @typedef {import('../../../../app/models/record-model').EnketoRecord} EnketoRecord
@@ -73,6 +74,10 @@ function getLastSavedRecord( enketoId ) {
  * @return { Promise<Survey> }
  */
 function setLastSavedRecord( enketoId, lastSavedRecord ) {
+    if ( encryptor.isEncrypted( lastSavedRecord ) ) {
+        return store.survey.get( enketoId );
+    }
+
     return store.survey.get( enketoId )
         .then( survey => {
             const update = Object.assign( {}, survey, { lastSavedRecord } );

--- a/public/js/src/module/form-cache.js
+++ b/public/js/src/module/form-cache.js
@@ -40,8 +40,7 @@ function init( survey ) {
             }
         } )
         .then( _processDynamicData )
-        .then( _setUpdateIntervals )
-        .then( _setResetListener );
+        .then( _setUpdateIntervals );
 }
 
 /**
@@ -200,24 +199,6 @@ function _setUpdateIntervals( survey ) {
     setInterval( () => {
         _updateCache( survey );
     }, CACHE_UPDATE_INTERVAL );
-
-    return Promise.resolve( survey );
-}
-
-/**
- * Form resets require reloading the form media.
- * This makes form resets slower, but it makes initial form loads faster.
- *
- * @param { Survey } survey - survey object
- * @return { Promise<Survey> }
- */
-function _setResetListener( survey ) {
-
-    document.addEventListener( events.FormReset().type, event => {
-        if ( event.target.nodeName.toLowerCase() === 'form' ) {
-            updateMedia( survey );
-        }
-    } );
 
     return Promise.resolve( survey );
 }

--- a/public/js/src/module/form-cache.js
+++ b/public/js/src/module/form-cache.js
@@ -78,6 +78,17 @@ function getLastSavedRecord( enketoId ) {
 }
 
 /**
+ * @param {Survey} survey
+ */
+function _isLastSaveEnabled( survey ) {
+    return (
+        survey.externalData != null &&
+        survey.externalData.find( data => data.src === LAST_SAVED_VIRTUAL_ENDPOINT ) != null &&
+        !encryptor.isEncryptionEnabled( survey )
+    );
+}
+
+/**
  *
  * @param { string } enketoId
  * @param { EnketoRecord } lastSavedRecord
@@ -86,7 +97,7 @@ function getLastSavedRecord( enketoId ) {
 function setLastSavedRecord( enketoId, lastSavedRecord ) {
     return store.survey.get( enketoId )
         .then( survey => {
-            if ( encryptor.isEncryptionEnabled( survey ) ) {
+            if ( !_isLastSaveEnabled( survey ) ) {
                 return Promise.resolve( survey );
             }
 
@@ -455,6 +466,10 @@ function _updateCache( survey ) {
                     .then( formParts => {
                         // media will be updated next time the form is loaded if resources is undefined
                         formParts.resources = undefined;
+
+                        if ( !_isLastSaveEnabled( formParts ) ) {
+                            delete formParts.lastSavedRecord;
+                        }
 
                         return formParts;
                     } )

--- a/public/js/src/module/form-cache.js
+++ b/public/js/src/module/form-cache.js
@@ -74,12 +74,12 @@ function getLastSavedRecord( enketoId ) {
  * @return { Promise<Survey> }
  */
 function setLastSavedRecord( enketoId, lastSavedRecord ) {
-    if ( encryptor.isEncrypted( lastSavedRecord ) ) {
-        return store.survey.get( enketoId );
-    }
-
     return store.survey.get( enketoId )
         .then( survey => {
+            if ( encryptor.isEncryptionEnabled( survey ) ) {
+                return Promise.resolve( survey );
+            }
+
             const update = Object.assign( {}, survey, { lastSavedRecord } );
 
             return store.survey.update( update );

--- a/public/js/src/module/form-cache.js
+++ b/public/js/src/module/form-cache.js
@@ -116,7 +116,7 @@ function remove( survey ) {
 
 /**
  * @param {Survey} survey
- * @return {PRomise<Survey>}
+ * @return {Promise<Survey>}
  */
 function _processDynamicData( survey ) {
     // TODO: In the future this method could perhaps be used to also store

--- a/public/js/src/module/records-queue.js
+++ b/public/js/src/module/records-queue.js
@@ -73,21 +73,29 @@ function set( record ) {
  * @param { 'set' | 'update' } action - determines whether to create or update the record
  * @param { EnketoRecord } record - the record to save
  *
- * @return { Promise<undefined> }
+ * @return { Promise<EnketoRecord> }
  */
 function save( action, record ) {
     /** @type { Promise<EnketoRecord> } */
+    let promise;
+
+    /** @type { EnketoRecord } */
     let result;
 
     if ( action === 'set' ) {
-        result = set( record );
+        promise = set( record );
     } else {
-        result = store.record.update( record );
+        promise = store.record.update( record );
     }
 
-    return result.then( record => {
-        return formCache.setLastSavedRecord( record.enketoId, record );
-    } ).then( _updateRecordList );
+    return promise
+        .then( record => {
+            result = record;
+
+            return formCache.setLastSavedRecord( record.enketoId, record );
+        } )
+        .then( _updateRecordList )
+        .then( () => result );
 }
 
 /**

--- a/public/js/src/module/records-queue.js
+++ b/public/js/src/module/records-queue.js
@@ -364,10 +364,9 @@ uploadProgress = {
 };
 
 /**
- * Retrieves a list of records for the active form, excluding auto-saved
- * and last-saved records. This was isolated from the `_updateRecordList`
- * function to allow testing, and reused in `uploadQueue` to share the
- * behavior.
+ * Retrieves a list of records for the active form, excluding auto-saved records.
+ * This was isolated from the `_updateRecordList` function to allow testing, and
+ * reused in `uploadQueue` to share the behavior.
  *
  * @param { { finalOnly?: boolean } } [options] - Only included records that are 'final' (i.e. not 'draft')
  * @return { Promise<Record[]> } - records to be displayed in the UI

--- a/public/js/src/module/records-queue.js
+++ b/public/js/src/module/records-queue.js
@@ -60,19 +60,28 @@ function set( record ) {
             }
 
             return store.record.set( record );
-        } )
-        .then( _updateRecordList );
+        } );
 }
 
 /**
- * Updates an existing record
+ * Creates (sets) or updates a record.
  *
- * @param  { object } record - a record object
- * @return { Promise } a promise that resolves with undefined
+ * @param { 'set' | 'update' } action - determines whether to create or update the record
+ * @param { Record } record - the record to save
+ *
+ * @return { Promise<undefined> }
  */
-function update( record ) {
-    return store.record.update( record )
-        .then( _updateRecordList );
+function save( action, record ) {
+    /** @type { Promise<Record> } */
+    let result;
+
+    if ( action === 'set' ) {
+        result = set( record );
+    } else {
+        result = store.record.update( record );
+    }
+
+    return result.then( _updateRecordList );
 }
 
 /**
@@ -419,8 +428,7 @@ function flush() {
 export default {
     init,
     get,
-    set,
-    update,
+    save,
     remove,
     getAutoSavedKey,
     getAutoSavedRecord,

--- a/public/js/src/module/records-queue.js
+++ b/public/js/src/module/records-queue.js
@@ -212,7 +212,7 @@ function uploadQueue() {
                 return;
             }
 
-            return store.record.getAll( settings.enketoId, true );
+            return getDisplayableRecordList( settings.enketoId, { finalOnly: true } );
         } )
         .then( records => {
             if ( !records || records.length === 0 ) {
@@ -368,12 +368,13 @@ uploadProgress = {
  * This was isolated from the `_updateRecordList` function to allow testing, and
  * reused in `uploadQueue` to share the behavior.
  *
+ * @param { string } enketoId
  * @param { { finalOnly?: boolean } } [options] - Only included records that are 'final' (i.e. not 'draft')
  * @return { Promise<Record[]> } - records to be displayed in the UI
  */
-function getDisplayableRecordList( { finalOnly = false } ) {
+function getDisplayableRecordList( enketoId, { finalOnly = false } = {} ) {
     const autoSavedKey = getAutoSavedKey();
-    const records = store.record.getAll( settings.enketoId, finalOnly )
+    const records = store.record.getAll( enketoId, finalOnly )
         .then( records => {
             return records.filter( record => record.instanceId !== autoSavedKey );
         } );
@@ -396,11 +397,8 @@ function _updateRecordList() {
     finalRecordPresent = false;
 
     // rebuild the list
-    return store.record.getAll( settings.enketoId )
+    return getDisplayableRecordList( settings.enketoId )
         .then( records => {
-            // remove autoSaved record
-            records = records.filter( record => record.instanceId !== getAutoSavedKey() );
-
             // update queue number
             $queueNumber.text( records.length );
 

--- a/public/js/src/module/store.js
+++ b/public/js/src/module/store.js
@@ -294,7 +294,6 @@ const surveyStore = {
         const binaryDefaultKeys = [].concat( survey.binaryDefaults || [] ).map( resource => resource.url );
 
         return server.surveys.get( survey.enketoId )
-            .then( _deserializeSurvey )
             .then( result => {
                 // Determine obsolete resources to be removed
                 // But if undefined, do not determine this!

--- a/public/js/src/module/store.js
+++ b/public/js/src/module/store.js
@@ -315,7 +315,7 @@ const surveyStore = {
                 }
 
                 if ( survey.binaryDefaults ) {
-                    update.resources = binaryDefaultKeys;
+                    update.binaryDefaults = binaryDefaultKeys;
                 }
 
                 // Update the existing survey

--- a/public/js/src/module/store.js
+++ b/public/js/src/module/store.js
@@ -680,6 +680,16 @@ function _firstItemOnly( results ) {
     }
 }
 
+/**
+ * Serializes a survey for storage in IndexedDB:
+ *
+ * - externalData XMLDocuments are serialized to strings
+ * - surveys with encryption enabled are converted to a state which can be deserialized on retrieval
+ *
+ * @see {encryptor.serializeEncryptedSurvey}
+ * @param {Survey} survey
+ * @return {Promise<Survey>}
+ */
 function _serializeSurvey( survey ) {
     if ( survey ) {
         if ( survey.externalData ) {
@@ -696,6 +706,16 @@ function _serializeSurvey( survey ) {
     }
 }
 
+/**
+ * Deserializes a survey retrieved from IndexedDB:
+ *
+ * - externalData strings are deserialized to XMLDocuments
+ * - surveys which should have encryption enabled are restored to that state
+ *
+ * @see {encryptor.deserializeEncryptedSurvey}
+ * @param {Survey} survey
+ * @return {Promise<Survey>}
+ */
 function _deserializeSurvey( survey ) {
     if ( survey ) {
         if ( survey.externalData ) {

--- a/public/js/src/module/store.js
+++ b/public/js/src/module/store.js
@@ -6,6 +6,8 @@ import db from 'db.js';
 import utils from './utils';
 import sniffer from './sniffer';
 import { t } from './translator';
+import encryptor from './encryptor';
+
 const parser = new DOMParser();
 
 /**
@@ -239,18 +241,18 @@ const surveyStore = {
     /**
      * Obtains a single survey's form HTML and XML model, theme, external instances from storage
      *
-     * @param  { object } id - [description]
+     * @param  { string } id - [description]
      * @return { Promise<Survey> }    [description]
      */
     get( id ) {
         return server.surveys.get( id )
             .then( _firstItemOnly )
-            .then( _transformExternalDataToXmlDoc );
+            .then( _deserializeSurvey );
     },
     /**
      * Stores a single survey's form HTML and XML model, theme, external instances
      *
-     * @param { object } survey - [description]
+     * @param { Survey } survey - [description]
      * @return { Promise<Survey> }        [description]
      */
     set( survey ) {
@@ -258,7 +260,7 @@ const surveyStore = {
             throw new Error( 'Survey not complete' );
         }
 
-        return server.surveys.add( _transformExternalDataToXmlStr( survey ) )
+        return server.surveys.add( _serializeSurvey( survey ) )
             .then( _firstItemOnly )
             .then( storedSurvey => {
                 const tasks = [];
@@ -272,12 +274,12 @@ const surveyStore = {
                     // return original survey with orginal survey.binaryDefaults
                     .then( () => storedSurvey );
             } )
-            .then( _transformExternalDataToXmlDoc );
+            .then( _deserializeSurvey );
     },
     /**
      * Updates a single survey's form HTML and XML model as well any external resources belonging to the form
      *
-     * @param  { object } survey - [description]
+     * @param  { Survey } survey - [description]
      * @return { Promise<Survey> }        [description]
      */
     update( survey ) {
@@ -292,6 +294,7 @@ const surveyStore = {
         const binaryDefaultKeys = [].concat( survey.binaryDefaults || [] ).map( resource => resource.url );
 
         return server.surveys.get( survey.enketoId )
+            .then( _deserializeSurvey )
             .then( result => {
                 // Determine obsolete resources to be removed
                 // But if undefined, do not determine this!
@@ -304,17 +307,23 @@ const surveyStore = {
                         .filter( existing => binaryDefaultKeys.indexOf( existing ) < 0 );
                 }
 
-                const update = Object.assign( {}, _transformExternalDataToXmlStr( survey ), {
-                    // Note: if survey.resources = undefined/null, do not store empty array
-                    // as it means there are no resources to store (and load) - they may be added later by form-cache.js
-                    resources: survey.resources ? resourceKeys : undefined,
-                    binaryDefaults: survey.binaryDefaults ? binaryDefaultKeys : undefined,
-                } );
+                let update = Object.assign( {}, _serializeSurvey( survey ) );
+
+                // Note: if survey.resources = undefined/null, do not store empty array
+                // as it means there are no resources to store (and load) - they may be added later by form-cache.js
+                if ( survey.resources ) {
+                    update.resources = resourceKeys;
+                }
+
+                if ( survey.binaryDefaults ) {
+                    update.resources = binaryDefaultKeys;
+                }
 
                 // Update the existing survey
                 return server.surveys.update( update );
             } )
-            .then( () => {
+            .then( _firstItemOnly )
+            .then( result => {
                 const tasks = [];
                 // Add new or update existing resources, combining binaryDefaults and form resources
                 ( survey.resources || [] ).concat( survey.binaryDefaults || [] ).forEach( file => {
@@ -322,14 +331,18 @@ const surveyStore = {
                 } );
                 // Remove obsolete resources
                 obsoleteResources.concat( obsoleteBinaryDefaults ).forEach( key => {
-                    tasks.push( surveyStore.resource.remove( survey.enketoId, key ) );
+                    tasks.push( surveyStore.resource.remove( survey.enketoId, key ).then( () => null ) );
                 } );
 
                 // Execution
                 return Promise.all( tasks )
-                    .then( () => // resolving with original survey (not the array returned by server.surveys.update)
-                        survey )
-                    .then( _transformExternalDataToXmlDoc );
+                    .then( resources => {
+                        if ( survey.resources ) {
+                            result.resources = resources.filter( resource => resource != null );
+                        }
+
+                        return _deserializeSurvey( result );
+                    } );
             } );
     },
     /**
@@ -668,32 +681,36 @@ function _firstItemOnly( results ) {
     }
 }
 
-function _transformExternalDataToXmlStr( survey ) {
-    if ( survey && survey.externalData ) {
-        survey.externalData = survey.externalData.map( instance => {
-            if ( instance.xml instanceof XMLDocument ) {
-                instance.xml = new XMLSerializer().serializeToString( instance.xml.documentElement, 'text/xml' );
-            }
+function _serializeSurvey( survey ) {
+    if ( survey ) {
+        if ( survey.externalData ) {
+            survey.externalData = survey.externalData.map( instance => {
+                if ( instance.xml instanceof XMLDocument ) {
+                    instance.xml = new XMLSerializer().serializeToString( instance.xml.documentElement, 'text/xml' );
+                }
 
-            return instance;
-        } );
+                return instance;
+            } );
+        }
+
+        return encryptor.serializeEncryptedSurvey( survey );
     }
-
-    return survey;
 }
 
-function _transformExternalDataToXmlDoc( survey ) {
-    if ( survey && survey.externalData ) {
-        survey.externalData = survey.externalData.map( instance => {
-            if ( typeof instance.xml === 'string' ) {
-                instance.xml = parser.parseFromString( instance.xml, 'text/xml' );
-            }
+function _deserializeSurvey( survey ) {
+    if ( survey ) {
+        if ( survey.externalData ) {
+            survey.externalData = survey.externalData.map( instance => {
+                if ( typeof instance.xml === 'string' ) {
+                    instance.xml = parser.parseFromString( instance.xml, 'text/xml' );
+                }
 
-            return instance;
-        } );
+                return instance;
+            } );
+        }
+
+        return encryptor.deserializeEncryptedSurvey( survey );
     }
-
-    return survey;
 }
 
 /**

--- a/test/client/connection.spec.js
+++ b/test/client/connection.spec.js
@@ -8,8 +8,10 @@ import connection from '../../public/js/src/module/connection';
 import settings from '../../public/js/src/module/settings';
 
 /**
- * @typedef {import('./feature/last-saved.spec.js')} LastSavedFeatureSpec
+ * @see {@link https://github.com/enketo/enketo-express/pull/269#issuecomment-861887583}
+ * TODO [2021-07-16]: remove this polyfill when CI is able to use a newer version of Chrome
  */
+import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
 
 /**
  * @typedef {import('../../app/models/record-model').EnketoRecord} EnketoRecord

--- a/test/client/connection.spec.js
+++ b/test/client/connection.spec.js
@@ -9,9 +9,14 @@ import settings from '../../public/js/src/module/settings';
 
 /**
  * @see {@link https://github.com/enketo/enketo-express/pull/269#issuecomment-861887583}
- * TODO [2021-07-16]: remove this polyfill when CI is able to use a newer version of Chrome
+ * TODO [2021-07-22]: remove these polyfills when CI is able to use a newer version of Chrome
  */
 import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
+import fromEntries from 'object.fromentries'; 'object.fromentries';
+if ( Object.fromEntries == null ) {
+    fromEntries.shim();
+}
+
 
 /**
  * @typedef {import('../../app/models/record-model').EnketoRecord} EnketoRecord

--- a/test/client/connection.spec.js
+++ b/test/client/connection.spec.js
@@ -1,0 +1,317 @@
+import connection from '../../public/js/src/module/connection';
+import formCache from '../../public/js/src/module/form-cache';
+import records from '../../public/js/src/module/records-queue';
+import settings from '../../public/js/src/module/settings';
+import store from '../../public/js/src/module/store';
+
+/**
+ * @typedef {import('../../app/models/record-model').EnketoRecord} EnketoRecord
+ */
+
+/**
+ * @typedef {import('../../app/models/survey-model').SurveyObject} Survey
+ */
+
+/**
+ * @typedef SinonSandbox { import('sinon').SinonSandbox }
+ */
+
+/**
+ * @typedef StubbedRequest
+ * @property { string } url
+ * @property { window.RequestInit } init
+ */
+
+describe( 'Connection', () => {
+    const enketoId = 'surveyA';
+    const instanceId = 'recordA';
+    const xmlSerializer = new XMLSerializer();
+
+    const baseSurvey = {
+        openRosaId: 'formA',
+        openRosaServer: 'http://localhost:3000',
+        enketoId,
+        theme: '',
+    };
+
+    const fullSurvey = Object.assign( {}, baseSurvey, {
+        form: '<form class="or"><img src="/path/to/source.png"/></form>',
+        model: '<model/>',
+        hash: '12345',
+    } );
+
+    describe( 'Uploading records', () => {
+
+        /** @type { SinonSandbox } */
+        let sandbox;
+
+        /** @type {Survey} */
+        let survey;
+
+        /** @type { EnketoRecord } */
+        let record;
+
+        /** @type { StubbedRequest[] } */
+        let requests;
+
+        /** @type { window.Response } */
+        let response;
+
+        const stubSuccessRespopnse = () => {
+            response = {
+                ok: true,
+                status: 201,
+                text() {
+                    return Promise.resolve( `
+                        <OpenRosaResponse xmlns="http://openrosa.org/http/response">
+                            <message nature="submit_success">Success</message>
+                        </OpenRosaResponse>
+                    ` );
+                },
+            };
+        };
+
+        beforeEach( () => {
+            response = {
+                status: 500,
+                text() {
+                    return Promise.resolve( '<error>No stub response designated by test</error>' );
+                },
+            };
+
+            requests = [];
+
+            survey = Object.assign( {}, baseSurvey );
+
+            record = {
+                enketoId,
+                instanceId,
+                name: 'name A',
+                xml: '<model><something>a</something></model>',
+                files: [],
+            };
+
+            sandbox = sinon.createSandbox();
+            sandbox.stub( settings, 'enketoId' ).get( () => enketoId );
+
+            sandbox.stub( window, 'fetch' ).callsFake( ( url, init ) => {
+                requests.push( { url, init } );
+
+                return Promise.resolve( response );
+            } );
+        } );
+
+        afterEach( () => {
+            sandbox.restore();
+        } );
+
+        it( 'uploads a record', done => {
+            stubSuccessRespopnse();
+
+            connection.uploadRecord( record )
+                .then( result => {
+                    expect( result.status ).to.equal( 201 );
+                    expect( requests.length ).to.equal( 1 );
+
+                    const request = requests[0];
+                    const body = Object.fromEntries( request.init.body.entries() );
+                    const instanceId = request.init.headers['X-OpenRosa-Instance-Id'];
+                    const submission = body.xml_submission_file;
+
+                    expect( instanceId ).to.equal( record.instanceId );
+                    expect( submission instanceof File ).to.equal( true );
+
+                    return submission.text();
+                } )
+                .then( submission => {
+                    expect( submission ).to.equal( record.xml );
+                } )
+                .then( done, done );
+        } );
+
+        describe( 'last-saved records', () => {
+            beforeEach( done => {
+                const autoSavedKey = records.getAutoSavedKey();
+
+                survey = Object.assign( {}, fullSurvey );
+
+                store.init()
+                    .then( records.init )
+                    .then( () => store.survey.set( survey ) )
+                    .then( () => {
+                        return store.record.set( {
+                            draft: true,
+                            instanceId: autoSavedKey,
+                            enketoId,
+                            name: `__autoSave_${Date.now()}`,
+                            xml: '<model><autosaved/></model>',
+                            files: [],
+                        } );
+                    } )
+                    .then( () => done(), done );
+            } );
+
+            afterEach( done => {
+                store.property.removeAll()
+                    .then( () => store.record.removeAll() )
+                    .then( () => store.survey.removeAll() )
+                    .then( done, done );
+            } );
+
+            it( 'creates a last-saved record on upload when specified in options', done => {
+                const originalRecord = Object.assign( {}, record );
+
+                stubSuccessRespopnse();
+
+                connection.uploadRecord( record, { isLastSaved: true } )
+                    .then( () => {
+                        return formCache.getLastSavedRecord( enketoId );
+                    } )
+                    .then( ( record ) => {
+                        expect( record ).to.deep.equal( originalRecord );
+                    } )
+                    .then( done, done );
+            } );
+
+            // Note: this allows records-queue to continue to upload when transitioning
+            // from offline to online.
+            it( 'does not create a last-saved record on upload by default', done => {
+                stubSuccessRespopnse();
+
+                connection.uploadRecord( record )
+                    .then( () => {
+                        return formCache.getLastSavedRecord( enketoId );
+                    } )
+                    .then( ( record ) => {
+                        expect( record ).to.equal( undefined );
+                    } )
+                    .then( done, done );
+            } );
+        } );
+    } );
+
+    describe( 'Getting form parts', () => {
+        const enketoId = 'surveyA';
+        const instanceId = 'recordA';
+        const defaultInstanceData = '<data id="modelA"><item>initial</item><meta><instanceID/></meta></data>';
+
+        /** @type { SinonSandbox } */
+        let sandbox;
+
+        /** @type {Survey} */
+        let survey;
+
+        /** @type { window.Response } */
+        let response;
+
+        const stubSuccessRespopnse = () => {
+            response = {
+                ok: true,
+                status: 201,
+                json() {
+                    return Promise.resolve( {
+                        form: '<form autocomplete="off" novalidate="novalidate" class="or clearfix" dir="ltr" id="surveyA"><!--This form was created by transforming an ODK/OpenRosa-flavored (X)Form using an XSL stylesheet created by Enketo LLC.--><section class="form-logo"></section><h3 dir="auto" id="form-title">Form with last-saved instance</h3><label class="question non-select "><span lang="" class="question-label active">Last saved</span><input type="text" name="/data/item" data-type-xml="string" data-setvalue="instance(\'last-saved\')/data/item" data-event="odk-instance-first-load"></label><fieldset id="or-setvalue-items" style="display:none;"></fieldset></form>',
+                        model: `<model><instance>${defaultInstanceData}</instance><instance id="last-saved" src="jr://instance/last-saved"/></model>`,
+                        theme: '',
+                        hash: 'md5:1fbbe9738efec026b5a14aa3c3152221--2a8178bb883ae91dfe205c168b54c0cf---1',
+                        languageMap: {},
+                    } );
+                },
+            };
+        };
+
+        beforeEach( done => {
+            survey = Object.assign( {}, fullSurvey );
+
+            sandbox = sinon.createSandbox();
+            sandbox.stub( settings, 'enketoId' ).get( () => enketoId );
+
+            sandbox.stub( window, 'fetch' ).callsFake( () => {
+                return Promise.resolve( response );
+            } );
+
+            store.init()
+                .then( records.init )
+                .then( store.survey.set( survey ) )
+                .then( () => done(), done );
+        } );
+
+        afterEach( done => {
+            store.property.removeAll()
+                .then( () => store.record.removeAll() )
+                .then( () => store.survey.removeAll() )
+                .then( () => {
+                    sandbox.restore();
+                } )
+                .then( done, done );
+        } );
+
+        it( 'includes the currently stored `lastSavedRecord` top-level property', done => {
+            stubSuccessRespopnse();
+
+            const lastSavedRecord = {
+                enketoId,
+                instanceId,
+                name: 'name A',
+                xml: '<data id="surveyA"><item>populated</item><meta><instanceID>uuid:ea3baa91-74b5-4892-af6f-96267f7fe12e</instanceID></meta></data>',
+                files: [],
+            };
+
+            formCache.setLastSavedRecord( enketoId, lastSavedRecord )
+                .then( () => connection.getFormParts( { enketoId } ) )
+                .then( result => {
+                    expect( result.lastSavedRecord ).to.deep.equal( lastSavedRecord );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'populates a last-saved secondary instance from the survey\'s last-saved record', done => {
+            stubSuccessRespopnse();
+
+            const lastSavedRecord = {
+                enketoId,
+                instanceId,
+                name: 'name A',
+                xml: '<data id="surveyA"><item>populated</item><meta><instanceID>uuid:ea3baa91-74b5-4892-af6f-96267f7fe12e</instanceID></meta></data>',
+                files: [],
+            };
+
+            formCache.setLastSavedRecord( enketoId, lastSavedRecord )
+                .then( () => connection.getFormParts( { enketoId } ) )
+                .then( result => {
+                    expect( Array.isArray( result.externalData ) ).to.equal( true );
+                    expect( result.externalData.length ).to.equal( 1 );
+
+                    const data = result.externalData[0];
+
+                    expect( data.id ).to.equal( 'last-saved' );
+                    expect( data.src ).to.equal( 'jr://instance/last-saved' );
+
+                    const xml = xmlSerializer.serializeToString( data.xml.documentElement, 'text/xml' );
+
+                    expect( xml ).to.equal( lastSavedRecord.xml );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'populates a last-saved secondary instance with the model\'s defaults when no last-saved record is available', done => {
+            stubSuccessRespopnse();
+
+            connection.getFormParts( { enketoId } )
+                .then( result => {
+                    expect( Array.isArray( result.externalData ) ).to.equal( true );
+                    expect( result.externalData.length ).to.equal( 1 );
+
+                    const data = result.externalData[0];
+
+                    expect( data.id ).to.equal( 'last-saved' );
+                    expect( data.src ).to.equal( 'jr://instance/last-saved' );
+
+                    const xml = xmlSerializer.serializeToString( data.xml.documentElement, 'text/xml' );
+
+                    expect( xml ).to.equal( defaultInstanceData );
+                } )
+                .then( done, done );
+        } );
+    } );
+} );

--- a/test/client/connection.spec.js
+++ b/test/client/connection.spec.js
@@ -1,8 +1,15 @@
+/**
+ * @module connection.spec.js
+ * @description Tests for online mode network requests and related business logic.
+ * @see {LastSavedFeatureSpec}
+ */
+
 import connection from '../../public/js/src/module/connection';
-import formCache from '../../public/js/src/module/form-cache';
-import records from '../../public/js/src/module/records-queue';
 import settings from '../../public/js/src/module/settings';
-import store from '../../public/js/src/module/store';
+
+/**
+ * @typedef {import('./feature/last-saved.spec.js')} LastSavedFeatureSpec
+ */
 
 /**
  * @typedef {import('../../app/models/record-model').EnketoRecord} EnketoRecord
@@ -25,28 +32,11 @@ import store from '../../public/js/src/module/store';
 describe( 'Connection', () => {
     const enketoId = 'surveyA';
     const instanceId = 'recordA';
-    const xmlSerializer = new XMLSerializer();
-
-    const baseSurvey = {
-        openRosaId: 'formA',
-        openRosaServer: 'http://localhost:3000',
-        enketoId,
-        theme: '',
-    };
-
-    const fullSurvey = Object.assign( {}, baseSurvey, {
-        form: '<form class="or"><img src="/path/to/source.png"/></form>',
-        model: '<model/>',
-        hash: '12345',
-    } );
 
     describe( 'Uploading records', () => {
 
         /** @type { SinonSandbox } */
         let sandbox;
-
-        /** @type {Survey} */
-        let survey;
 
         /** @type { EnketoRecord } */
         let record;
@@ -54,34 +44,8 @@ describe( 'Connection', () => {
         /** @type { StubbedRequest[] } */
         let requests;
 
-        /** @type { window.Response } */
-        let response;
-
-        const stubSuccessRespopnse = () => {
-            response = {
-                ok: true,
-                status: 201,
-                text() {
-                    return Promise.resolve( `
-                        <OpenRosaResponse xmlns="http://openrosa.org/http/response">
-                            <message nature="submit_success">Success</message>
-                        </OpenRosaResponse>
-                    ` );
-                },
-            };
-        };
-
         beforeEach( () => {
-            response = {
-                status: 500,
-                text() {
-                    return Promise.resolve( '<error>No stub response designated by test</error>' );
-                },
-            };
-
             requests = [];
-
-            survey = Object.assign( {}, baseSurvey );
 
             record = {
                 enketoId,
@@ -97,7 +61,17 @@ describe( 'Connection', () => {
             sandbox.stub( window, 'fetch' ).callsFake( ( url, init ) => {
                 requests.push( { url, init } );
 
-                return Promise.resolve( response );
+                return Promise.resolve( {
+                    ok: true,
+                    status: 201,
+                    text() {
+                        return Promise.resolve( `
+                            <OpenRosaResponse xmlns="http://openrosa.org/http/response">
+                                <message nature="submit_success">Success</message>
+                            </OpenRosaResponse>
+                        ` );
+                    },
+                } );
             } );
         } );
 
@@ -106,8 +80,6 @@ describe( 'Connection', () => {
         } );
 
         it( 'uploads a record', done => {
-            stubSuccessRespopnse();
-
             connection.uploadRecord( record )
                 .then( result => {
                     expect( result.status ).to.equal( 201 );
@@ -125,191 +97,6 @@ describe( 'Connection', () => {
                 } )
                 .then( submission => {
                     expect( submission ).to.equal( record.xml );
-                } )
-                .then( done, done );
-        } );
-
-        describe( 'last-saved records', () => {
-            beforeEach( done => {
-                const autoSavedKey = records.getAutoSavedKey();
-
-                survey = Object.assign( {}, fullSurvey );
-
-                store.init()
-                    .then( records.init )
-                    .then( () => store.survey.set( survey ) )
-                    .then( () => {
-                        return store.record.set( {
-                            draft: true,
-                            instanceId: autoSavedKey,
-                            enketoId,
-                            name: `__autoSave_${Date.now()}`,
-                            xml: '<model><autosaved/></model>',
-                            files: [],
-                        } );
-                    } )
-                    .then( () => done(), done );
-            } );
-
-            afterEach( done => {
-                store.property.removeAll()
-                    .then( () => store.record.removeAll() )
-                    .then( () => store.survey.removeAll() )
-                    .then( done, done );
-            } );
-
-            it( 'creates a last-saved record on upload when specified in options', done => {
-                const originalRecord = Object.assign( {}, record );
-
-                stubSuccessRespopnse();
-
-                connection.uploadRecord( record, { isLastSaved: true } )
-                    .then( () => {
-                        return formCache.getLastSavedRecord( enketoId );
-                    } )
-                    .then( ( record ) => {
-                        expect( record ).to.deep.equal( originalRecord );
-                    } )
-                    .then( done, done );
-            } );
-
-            // Note: this allows records-queue to continue to upload when transitioning
-            // from offline to online.
-            it( 'does not create a last-saved record on upload by default', done => {
-                stubSuccessRespopnse();
-
-                connection.uploadRecord( record )
-                    .then( () => {
-                        return formCache.getLastSavedRecord( enketoId );
-                    } )
-                    .then( ( record ) => {
-                        expect( record ).to.equal( undefined );
-                    } )
-                    .then( done, done );
-            } );
-        } );
-    } );
-
-    describe( 'Getting form parts', () => {
-        const enketoId = 'surveyA';
-        const instanceId = 'recordA';
-        const defaultInstanceData = '<data id="modelA"><item>initial</item><meta><instanceID/></meta></data>';
-
-        /** @type { SinonSandbox } */
-        let sandbox;
-
-        /** @type {Survey} */
-        let survey;
-
-        /** @type { window.Response } */
-        let response;
-
-        const stubSuccessRespopnse = () => {
-            response = {
-                ok: true,
-                status: 201,
-                json() {
-                    return Promise.resolve( {
-                        form: '<form autocomplete="off" novalidate="novalidate" class="or clearfix" dir="ltr" id="surveyA"><!--This form was created by transforming an ODK/OpenRosa-flavored (X)Form using an XSL stylesheet created by Enketo LLC.--><section class="form-logo"></section><h3 dir="auto" id="form-title">Form with last-saved instance</h3><label class="question non-select "><span lang="" class="question-label active">Last saved</span><input type="text" name="/data/item" data-type-xml="string" data-setvalue="instance(\'last-saved\')/data/item" data-event="odk-instance-first-load"></label><fieldset id="or-setvalue-items" style="display:none;"></fieldset></form>',
-                        model: `<model><instance>${defaultInstanceData}</instance><instance id="last-saved" src="jr://instance/last-saved"/></model>`,
-                        theme: '',
-                        hash: 'md5:1fbbe9738efec026b5a14aa3c3152221--2a8178bb883ae91dfe205c168b54c0cf---1',
-                        languageMap: {},
-                    } );
-                },
-            };
-        };
-
-        beforeEach( done => {
-            survey = Object.assign( {}, fullSurvey );
-
-            sandbox = sinon.createSandbox();
-            sandbox.stub( settings, 'enketoId' ).get( () => enketoId );
-
-            sandbox.stub( window, 'fetch' ).callsFake( () => {
-                return Promise.resolve( response );
-            } );
-
-            store.init()
-                .then( records.init )
-                .then( store.survey.set( survey ) )
-                .then( () => done(), done );
-        } );
-
-        afterEach( done => {
-            store.property.removeAll()
-                .then( () => store.record.removeAll() )
-                .then( () => store.survey.removeAll() )
-                .then( () => {
-                    sandbox.restore();
-                } )
-                .then( done, done );
-        } );
-
-        it( 'includes the currently stored `lastSavedRecord` top-level property', done => {
-            stubSuccessRespopnse();
-
-            const lastSavedRecord = {
-                enketoId,
-                instanceId,
-                name: 'name A',
-                xml: '<data id="surveyA"><item>populated</item><meta><instanceID>uuid:ea3baa91-74b5-4892-af6f-96267f7fe12e</instanceID></meta></data>',
-                files: [],
-            };
-
-            formCache.setLastSavedRecord( enketoId, lastSavedRecord )
-                .then( () => connection.getFormParts( { enketoId } ) )
-                .then( result => {
-                    expect( result.lastSavedRecord ).to.deep.equal( lastSavedRecord );
-                } )
-                .then( done, done );
-        } );
-
-        it( 'populates a last-saved secondary instance from the survey\'s last-saved record', done => {
-            stubSuccessRespopnse();
-
-            const lastSavedRecord = {
-                enketoId,
-                instanceId,
-                name: 'name A',
-                xml: '<data id="surveyA"><item>populated</item><meta><instanceID>uuid:ea3baa91-74b5-4892-af6f-96267f7fe12e</instanceID></meta></data>',
-                files: [],
-            };
-
-            formCache.setLastSavedRecord( enketoId, lastSavedRecord )
-                .then( () => connection.getFormParts( { enketoId } ) )
-                .then( result => {
-                    expect( Array.isArray( result.externalData ) ).to.equal( true );
-                    expect( result.externalData.length ).to.equal( 1 );
-
-                    const data = result.externalData[0];
-
-                    expect( data.id ).to.equal( 'last-saved' );
-                    expect( data.src ).to.equal( 'jr://instance/last-saved' );
-
-                    const xml = xmlSerializer.serializeToString( data.xml.documentElement, 'text/xml' );
-
-                    expect( xml ).to.equal( lastSavedRecord.xml );
-                } )
-                .then( done, done );
-        } );
-
-        it( 'populates a last-saved secondary instance with the model\'s defaults when no last-saved record is available', done => {
-            stubSuccessRespopnse();
-
-            connection.getFormParts( { enketoId } )
-                .then( result => {
-                    expect( Array.isArray( result.externalData ) ).to.equal( true );
-                    expect( result.externalData.length ).to.equal( 1 );
-
-                    const data = result.externalData[0];
-
-                    expect( data.id ).to.equal( 'last-saved' );
-                    expect( data.src ).to.equal( 'jr://instance/last-saved' );
-
-                    const xml = xmlSerializer.serializeToString( data.xml.documentElement, 'text/xml' );
-
-                    expect( xml ).to.equal( defaultInstanceData );
                 } )
                 .then( done, done );
         } );

--- a/test/client/connection.spec.js
+++ b/test/client/connection.spec.js
@@ -100,7 +100,7 @@ describe( 'Connection', () => {
                     expect( instanceId ).to.equal( record.instanceId );
                     expect( submission instanceof File ).to.equal( true );
 
-                    return submission.text();
+                    return ( new Response( submission ) ).text();
                 } )
                 .then( submission => {
                     expect( submission ).to.equal( record.xml );

--- a/test/client/encryptor.spec.js
+++ b/test/client/encryptor.spec.js
@@ -56,6 +56,7 @@ describe( 'Encryptor', () => {
             encryptor.encryptRecord( form, record )
                 .then( encryptedRecord => {
                     const doc = new DOMParser().parseFromString( encryptedRecord.xml, 'text/xml' );
+                    expect( encryptor.isEncrypted( record ) ).to.equal( true );
                     expect( doc.querySelectorAll( 'data' ).length ).to.equal( 1 );
                     expect( doc.querySelector( 'data' ).namespaceURI ).to.equal( SUBMISSION_NS );
                     expect( doc.querySelector( 'data' ).getAttribute( 'id' ) ).to.equal( 'abc' );

--- a/test/client/encryptor.spec.js
+++ b/test/client/encryptor.spec.js
@@ -44,6 +44,28 @@ describe( 'Encryptor', () => {
 
     } );
 
+    describe( 'survey encryption', () => {
+        let survey;
+
+        beforeEach( () => {
+            survey = {
+                openRosaId: 'formA',
+                openRosaServer: 'http://localhost:3000',
+                enketoId: 'surveyA',
+                theme: '',
+            };
+        } );
+
+        it( 'is not enabled by default', () => {
+            expect( encryptor.isEncryptionEnabled( survey ) ).to.equal( false );
+        } );
+
+        it( 'is enabled when set', () => {
+            const result = encryptor.setEncryptionEnabled( survey );
+
+            expect( encryptor.isEncryptionEnabled( result ) ).to.equal( true );
+        } );
+    } );
 
     describe( 'submission encryption', () => {
         const form = { id: 'abc', version: '2', encryptionKey: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5s9p+VdyX1ikG8nnoXLCC9hKfivAp/e1sHr3O15UQ+a8CjR/QV29+cO8zjS/KKgXZiOWvX+gDs2+5k9Kn4eQm5KhoZVw5Xla2PZtJESAd7dM9O5QrqVJ5Ukrq+kG/uV0nf6X8dxyIluNeCK1jE55J5trQMWT2SjDcj+OVoTdNGJ1H6FL+Horz2UqkIObW5/elItYF8zUZcO1meCtGwaPHxAxlvODe8JdKs3eMiIo9eTT4WbH1X+7nJ21E/FBd8EmnK/91UGOx2AayNxM0RN7pAcj47a434LzeM+XCnBztd+mtt1PSflF2CFE116ikEgLcXCj4aklfoON9TwDIQSp0wIDAQAB' };
@@ -56,7 +78,6 @@ describe( 'Encryptor', () => {
             encryptor.encryptRecord( form, record )
                 .then( encryptedRecord => {
                     const doc = new DOMParser().parseFromString( encryptedRecord.xml, 'text/xml' );
-                    expect( encryptor.isEncrypted( record ) ).to.equal( true );
                     expect( doc.querySelectorAll( 'data' ).length ).to.equal( 1 );
                     expect( doc.querySelector( 'data' ).namespaceURI ).to.equal( SUBMISSION_NS );
                     expect( doc.querySelector( 'data' ).getAttribute( 'id' ) ).to.equal( 'abc' );

--- a/test/client/encryptor.spec.js
+++ b/test/client/encryptor.spec.js
@@ -1,3 +1,13 @@
+/**
+ * @module encryptor.spec.js
+ * @description Tests encryption logic.
+ * @see {SurveyEncryptionSpec}
+ */
+
+/**
+ * @typedef {import('./feature/survey-encryption.spec.js')} SurveyEncryptionSpec
+ */
+
 import encryptor from '../../public/js/src/module/encryptor';
 
 describe( 'Encryptor', () => {
@@ -42,29 +52,6 @@ describe( 'Encryptor', () => {
             expect( array ).to.deep.equal( [ 27, 167, 251, 185, 158, 88, 117, 19, 87, 101, 26, 165, 28, 113, 193, 231 ] );
         } );
 
-    } );
-
-    describe( 'survey encryption', () => {
-        let survey;
-
-        beforeEach( () => {
-            survey = {
-                openRosaId: 'formA',
-                openRosaServer: 'http://localhost:3000',
-                enketoId: 'surveyA',
-                theme: '',
-            };
-        } );
-
-        it( 'is not enabled by default', () => {
-            expect( encryptor.isEncryptionEnabled( survey ) ).to.equal( false );
-        } );
-
-        it( 'is enabled when set', () => {
-            const result = encryptor.setEncryptionEnabled( survey );
-
-            expect( encryptor.isEncryptionEnabled( result ) ).to.equal( true );
-        } );
     } );
 
     describe( 'submission encryption', () => {

--- a/test/client/feature/last-saved.spec.js
+++ b/test/client/feature/last-saved.spec.js
@@ -439,5 +439,32 @@ describe( 'Support for jr://instance/last-saved endpoint', () => {
                 } )
                 .then( done, done );
         } );
+
+        it( 'populates a last-saved secondary instance with the model\'s defaults when editing an instance', done => {
+            const lastSavedRecord = {
+                enketoId,
+                instanceId,
+                name: 'name A',
+                xml: '<data id="surveyA"><item>populated</item><meta><instanceID>uuid:ea3baa91-74b5-4892-af6f-96267f7fe12e</instanceID></meta></data>',
+                files: [],
+            };
+
+            formCache.setLastSavedRecord( enketoId, lastSavedRecord )
+                .then( () => connection.getFormParts( { enketoId, instanceId } ) )
+                .then( result => {
+                    expect( Array.isArray( result.externalData ) ).to.equal( true );
+                    expect( result.externalData.length ).to.equal( 1 );
+
+                    const data = result.externalData[0];
+
+                    expect( data.id ).to.equal( 'last-saved' );
+                    expect( data.src ).to.equal( 'jr://instance/last-saved' );
+
+                    const xml = xmlSerializer.serializeToString( data.xml.documentElement, 'text/xml' );
+
+                    expect( xml ).to.equal( defaultInstanceData );
+                } )
+                .then( done, done );
+        } );
     } );
 } );

--- a/test/client/feature/last-saved.spec.js
+++ b/test/client/feature/last-saved.spec.js
@@ -1,0 +1,429 @@
+/**
+ * @module last-saved.spec.js
+ * @description This module tests functionality around the
+ * `jr://instance/last-saved` virtual endpoint, including client storage and
+ * populating secondary instances.
+ * @see {@link https://getodk.github.io/xforms-spec/#virtual-endpoints}
+ * @see {@link https://getodk.github.io/xforms-spec/#secondary-instances---external}
+ * @see {ConnectionSpec}
+ * @see {RecordQueueSpec}
+ * @see {SurveyEncryptionFeatureSpec}
+ */
+
+import connection from '../../../public/js/src/module/connection';
+import formCache from '../../../public/js/src/module/form-cache';
+import records from '../../../public/js/src/module/records-queue';
+import settings from '../../../public/js/src/module/settings';
+import store from '../../../public/js/src/module/store';
+
+/**
+ * @typedef {import('../connection.spec.js')} ConnectionSpec
+ */
+
+/**
+ * @typedef {import('../records-queue.spec.js')} RecordQueueSpec
+ */
+
+/**
+ * @typedef {import('../store.spec.js')} StoreSpec
+ */
+
+/**
+ * @typedef {import('./survey-encryption.spec.js')} SurveyEncryptionFeatureSpec
+ */
+
+/**
+ * @typedef {import('../../app/models/record-model').EnketoRecord} EnketoRecord
+ */
+
+/**
+ * @typedef {import('../../app/models/survey-model').SurveyObject} Survey
+ */
+
+/**
+ * @typedef SinonSandbox { import('sinon').SinonSandbox }
+ */
+
+describe( 'Support for jr://instance/last-saved endpoint', () => {
+    const enketoIdA = 'surveyA';
+    const instanceIdA = 'recordA';
+    const enketoIdB = 'surveyB';
+    const instanceIdB = 'recordB';
+
+    /** @type {string} */
+    let autoSavedKey;
+
+    /** @type { string } */
+    let enketoId;
+
+    /** @type { SinonSandbox } */
+    let sandbox;
+
+    /** @type { Survey } */
+    let surveyA;
+
+    /** @type { Survey } */
+    let surveyB;
+
+    /** @type { EnketoRecord } */
+    let recordA;
+
+    /** @type { EnketoRecord } */
+    let recordB;
+
+    beforeEach( done => {
+        enketoId = enketoIdA;
+
+        sandbox = sinon.createSandbox();
+        sandbox.stub( settings, 'enketoId' ).get( () => enketoId );
+
+        autoSavedKey = records.getAutoSavedKey();
+
+        surveyA = {
+            openRosaId: 'formA',
+            openRosaServer: 'http://localhost:3000',
+            enketoId: enketoIdA,
+            theme: '',
+            form: `<form class="or"><img src="/path/to/${enketoIdA}.jpg"/></form>`,
+            model: '<model><foo/></model>',
+            hash: '12345',
+        };
+
+        surveyB = {
+            openRosaId: 'formB',
+            openRosaServer: 'http://localhost:3000',
+            enketoId: enketoIdB,
+            theme: '',
+            form: `<form class="or"><img src="/path/to/${enketoIdB}.jpg"/></form>`,
+            model: '<model><bar/></model>',
+            hash: '67890',
+        };
+
+        recordA = {
+            draft: false,
+            enketoId,
+            files: [],
+            instanceId: instanceIdA,
+            name: 'name A',
+            xml: '<model><something>a</something></model>',
+        };
+
+        recordB = {
+            draft: false,
+            enketoId,
+            files: [],
+            instanceId: 'b',
+            name: 'name B',
+            xml: '<model><something>b</something></model>',
+        };
+
+        store.init()
+            .then( records.init )
+            .then( () => store.record.set( {
+                draft: true,
+                instanceId: autoSavedKey,
+                enketoId,
+                name: `__autoSave_${Date.now()}`,
+                xml: '<model><autosaved/></model>',
+                files: [],
+            } ) )
+            .then( () => store.survey.set( surveyA ) )
+            .then( () => store.survey.set( surveyB ) )
+            .then( () => done(), done );
+    } );
+
+    afterEach( done => {
+        sandbox.restore();
+
+        Promise.all( [
+            store.property.removeAll(),
+            store.record.removeAll(),
+            store.survey.removeAll(),
+        ] ).then( () => done(), done );
+    } );
+
+    describe( 'storage for offline mode', () => {
+        it( 'creates a last-saved record when creating a record', done => {
+            const originalRecord = Object.assign( {}, recordA );
+
+            records.save( 'set', recordA )
+                .then( () => {
+                    return formCache.getLastSavedRecord( enketoId );
+                } )
+                .then( record => {
+                    Object.entries( originalRecord ).forEach( ( [ key, value ] ) => {
+                        expect( record[key] ).to.deep.equal( value );
+                    } );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'replaces a last-saved record when creating a newer record', done => {
+            const originalRecord = Object.assign( {}, recordA );
+
+            records.save( 'set', recordB )
+                .then( () => {
+                    return records.save( 'set', recordA );
+                } )
+                .then( () => {
+                    return formCache.getLastSavedRecord( enketoId );
+                } )
+                .then( record => {
+                    Object.entries( originalRecord ).forEach( ( [ key, value ] ) => {
+                        expect( record[key] ).to.deep.equal( value );
+                    } );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'creates a last-saved record when updating a record', done => {
+            const originalSurvey = Object.assign( {}, surveyA );
+
+            const update = {
+                draft: false,
+                enketoId,
+                instanceId: instanceIdA,
+                name: 'name A updated',
+                xml: '<model><updated/></model>'
+            };
+            const payload = Object.assign( {}, update );
+
+            records.save( 'set', recordA )
+                .then( () => {
+                    // This would be the condition in cases where a record already
+                    // existed before this feature was implemented
+                    return store.survey.update( originalSurvey );
+                } )
+                .then( () => {
+                    return records.save( 'update', update );
+                } )
+                .then( () => {
+                    return formCache.getLastSavedRecord( enketoId );
+                } )
+                .then( record => {
+                    Object.entries( payload ).forEach( ( [ key, value ] ) => {
+                        expect( record[key] ).to.deep.equal( value );
+                    } );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'replaces a last-saved record when updating a record', done => {
+            const update = {
+                draft: false,
+                enketoId,
+                instanceId: instanceIdA,
+                name: 'name A updated',
+                xml: '<model><updated/></model>'
+            };
+            const payload = Object.assign( {}, update );
+
+            records.save( 'set', recordA )
+                .then( () => {
+                    return records.save( 'update', update );
+                } )
+                .then( () => {
+                    return formCache.getLastSavedRecord( enketoId );
+                } )
+                .then( record => {
+                    Object.entries( payload ).forEach( ( [ key, value ] ) => {
+                        expect( record[key] ).to.deep.equal( value );
+                    } );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'creates separate last-saved records for different forms', done => {
+            const originalRecordA = Object.assign( {}, recordA );
+
+            /** @type { EnketoRecord } */
+            const recordB = {
+                draft: false,
+                enketoId: enketoIdB,
+                instanceId: instanceIdB,
+                name: 'name B',
+                xml: '<model><something>b</something></model>'
+            };
+
+            const originalRecordB = Object.assign( {}, recordB );
+
+            // Create record/last-saved for first form id
+            records.save( 'set', recordA )
+                // Create autosave record for second form id
+                .then( () => {
+                    enketoId = enketoIdB;
+
+                    return store.record.set( {
+                        draft: true,
+                        instanceId: records.getAutoSavedKey(),
+                        enketoId,
+                        name: `__autoSave_${Date.now()}`,
+                        xml: '<model><autosaved/></model>',
+                        files: [],
+                    } );
+                } )
+                // Create record/last-saved for second form id
+                .then( () => {
+                    return records.save( 'set', recordB );
+                } )
+                // Get last-saved record for second form id
+                .then( () => {
+                    return formCache.getLastSavedRecord( enketoId );
+                } )
+                // Validate last-saved record for second form id
+                .then( lastSavedB => {
+                    Object.entries( originalRecordB ).forEach( ( [ key, value ] ) => {
+                        expect( lastSavedB[key] ).to.deep.equal( value );
+                    } );
+                } )
+                // Get last-saved record for first form id
+                .then( () => {
+                    enketoId = enketoIdA;
+
+                    return formCache.getLastSavedRecord( enketoId );
+                } )
+                // Validate last-saved record for first form id has not changed
+                .then( lastSavedA => {
+                    Object.entries( originalRecordA ).forEach( ( [ key, value ] ) => {
+                        expect( lastSavedA[key] ).to.deep.equal( value );
+                    } );
+                } )
+                .then( done, done );
+        } );
+    } );
+
+    describe( 'storage for online mode', () => {
+        beforeEach( () => {
+            sandbox.stub( settings, 'enketoId' ).get( () => enketoId );
+
+            sandbox.stub( window, 'fetch' ).callsFake( () => {
+                return Promise.resolve( {
+                    ok: true,
+                    status: 201,
+                    text() {
+                        return Promise.resolve( `
+                            <OpenRosaResponse xmlns="http://openrosa.org/http/response">
+                                <message nature="submit_success">Success</message>
+                            </OpenRosaResponse>
+                        ` );
+                    },
+                } );
+            } );
+        } );
+
+        it( 'creates a last-saved record on upload when specified in options', done => {
+            const originalRecord = Object.assign( {}, recordA );
+
+            connection.uploadRecord( recordA, { isLastSaved: true } )
+                .then( () => {
+                    return formCache.getLastSavedRecord( enketoId );
+                } )
+                .then( ( record ) => {
+                    expect( record ).to.deep.equal( originalRecord );
+                } )
+                .then( done, done );
+        } );
+
+        // Note: this allows records-queue to continue to upload when transitioning
+        // from offline to online.
+        it( 'does not create a last-saved record on upload by default', done => {
+            connection.uploadRecord( recordA )
+                .then( () => {
+                    return formCache.getLastSavedRecord( enketoId );
+                } )
+                .then( ( record ) => {
+                    expect( record ).to.equal( undefined );
+                } )
+                .then( done, done );
+        } );
+    } );
+
+    describe( 'populating secondary instances', () => {
+        const enketoId = 'surveyA';
+        const instanceId = 'recordA';
+        const defaultInstanceData = '<data id="modelA"><item>initial</item><meta><instanceID/></meta></data>';
+        const xmlSerializer = new XMLSerializer();
+
+        beforeEach( () => {
+            sandbox.stub( settings, 'enketoId' ).get( () => enketoId );
+
+            sandbox.stub( window, 'fetch' ).callsFake( () => {
+                return Promise.resolve( {
+                    ok: true,
+                    status: 201,
+                    json() {
+                        return Promise.resolve( {
+                            form: '<form autocomplete="off" novalidate="novalidate" class="or clearfix" dir="ltr" id="surveyA"><!--This form was created by transforming an ODK/OpenRosa-flavored (X)Form using an XSL stylesheet created by Enketo LLC.--><section class="form-logo"></section><h3 dir="auto" id="form-title">Form with last-saved instance</h3><label class="question non-select "><span lang="" class="question-label active">Last saved</span><input type="text" name="/data/item" data-type-xml="string" data-setvalue="instance(\'last-saved\')/data/item" data-event="odk-instance-first-load"></label><fieldset id="or-setvalue-items" style="display:none;"></fieldset></form>',
+                            model: `<model><instance>${defaultInstanceData}</instance><instance id="last-saved" src="jr://instance/last-saved"/></model>`,
+                            theme: '',
+                            hash: 'md5:1fbbe9738efec026b5a14aa3c3152221--2a8178bb883ae91dfe205c168b54c0cf---1',
+                            languageMap: {},
+                        } );
+                    },
+                } );
+            } );
+        } );
+
+        it( 'includes the currently stored `lastSavedRecord` top-level property', done => {
+            const lastSavedRecord = {
+                enketoId,
+                instanceId,
+                name: 'name A',
+                xml: '<data id="surveyA"><item>populated</item><meta><instanceID>uuid:ea3baa91-74b5-4892-af6f-96267f7fe12e</instanceID></meta></data>',
+                files: [],
+            };
+
+            formCache.setLastSavedRecord( enketoId, lastSavedRecord )
+                .then( () => connection.getFormParts( { enketoId } ) )
+                .then( result => {
+                    expect( result.lastSavedRecord ).to.deep.equal( lastSavedRecord );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'populates a last-saved secondary instance from the survey\'s last-saved record', done => {
+            const lastSavedRecord = {
+                enketoId,
+                instanceId,
+                name: 'name A',
+                xml: '<data id="surveyA"><item>populated</item><meta><instanceID>uuid:ea3baa91-74b5-4892-af6f-96267f7fe12e</instanceID></meta></data>',
+                files: [],
+            };
+
+            formCache.setLastSavedRecord( enketoId, lastSavedRecord )
+                .then( () => connection.getFormParts( { enketoId } ) )
+                .then( result => {
+                    expect( Array.isArray( result.externalData ) ).to.equal( true );
+                    expect( result.externalData.length ).to.equal( 1 );
+
+                    const data = result.externalData[0];
+
+                    expect( data.id ).to.equal( 'last-saved' );
+                    expect( data.src ).to.equal( 'jr://instance/last-saved' );
+
+                    const xml = xmlSerializer.serializeToString( data.xml.documentElement, 'text/xml' );
+
+                    expect( xml ).to.equal( lastSavedRecord.xml );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'populates a last-saved secondary instance with the model\'s defaults when no last-saved record is available', done => {
+            connection.getFormParts( { enketoId } )
+                .then( result => {
+                    expect( Array.isArray( result.externalData ) ).to.equal( true );
+                    expect( result.externalData.length ).to.equal( 1 );
+
+                    const data = result.externalData[0];
+
+                    expect( data.id ).to.equal( 'last-saved' );
+                    expect( data.src ).to.equal( 'jr://instance/last-saved' );
+
+                    const xml = xmlSerializer.serializeToString( data.xml.documentElement, 'text/xml' );
+
+                    expect( xml ).to.equal( defaultInstanceData );
+                } )
+                .then( done, done );
+        } );
+    } );
+} );

--- a/test/client/feature/last-saved.spec.js
+++ b/test/client/feature/last-saved.spec.js
@@ -11,6 +11,7 @@
  */
 
 import connection from '../../../public/js/src/module/connection';
+import encryptor from '../../../public/js/src/module/encryptor';
 import formCache from '../../../public/js/src/module/form-cache';
 import records from '../../../public/js/src/module/records-queue';
 import settings from '../../../public/js/src/module/settings';
@@ -154,6 +155,287 @@ describe( 'Support for jr://instance/last-saved endpoint', () => {
             store.record.removeAll(),
             store.survey.removeAll(),
         ] ).then( () => done(), done );
+    } );
+
+    describe( 'surveys', () => {
+        /**
+         * @param {Partial<GetFormPartsStubResult>} updates
+         */
+        const updateSurvey = ( updates ) => {
+            // Ensure `_updateCache` receives a new hash indicating it should perform an update
+            sandbox.stub( connection, 'getFormPartsHash' ).callsFake( () => {
+                return Promise.resolve( updates.hash );
+            } );
+
+            let updatePromise = new Promise( resolve => {
+                setTimeout( resolve, formCache.CACHE_UPDATE_INITIAL_DELAY + 1 );
+            } );
+
+            const originalStoreUpdate = store.survey.update.bind( store.survey );
+
+            sandbox.stub( store.survey, 'update' ).callsFake( update => {
+                return originalStoreUpdate( update ).then( result => {
+                    if ( update.model === updates.model ) {
+                        timers.tick( 1 );
+                    }
+
+                    return result;
+                } );
+            } );
+
+            timers.tick( formCache.CACHE_UPDATE_INITIAL_DELAY );
+
+            getFormPartsStubResult = Object.assign( {}, getFormPartsStubResult, updates );
+
+            // Wait for `_updateCache` to resolve
+            return updatePromise.then( () => formCache.get( survey ) );
+        };
+
+        const url1 = '/path/to/source.png';
+        const form1 = `<form class="or"><img src="${url1}"/></form>`;
+        const defaultInstanceData = '<data id="modelA"><item>initial</item><meta><instanceID/></meta></data>';
+        const model1 = `<model><instance>${defaultInstanceData}</instance><instance id="last-saved" src="jr://instance/last-saved"/></model>`;
+        const hash1 = '12345';
+
+        const parser = new DOMParser();
+
+        /** @type { Survey } */
+        let survey;
+
+        /** @type {SurveyExternalData} */
+        let lastSavedExternalData;
+
+        /** @type {GetFormPartsStubResult} */
+        let getFormPartsStubResult;
+
+        /** @type {SinonFakeTimers} */
+        let timers;
+
+        /** @type {EnketoRecord} */
+        let record;
+
+        beforeEach( done => {
+            enketoId = 'surveyC';
+
+            record = {
+                draft: false,
+                enketoId,
+                instanceId: 'recordA',
+                name: 'name A',
+                xml: '<data id="modelA"><item>initial</item><meta><instanceID/></meta></data>',
+            };
+
+            survey = {
+                openRosaId: 'formC',
+                openRosaServer: 'http://localhost:3000',
+                enketoId,
+                theme: '',
+            };
+
+            sandbox.stub( settings, 'enketoId' ).get( () => enketoId );
+
+            // Prevent calls to `_updateCache` after tests complete/stubs are restored
+            timers = sinon.useFakeTimers();
+
+            lastSavedExternalData = {
+                id: 'last-saved',
+                src: 'jr://instance/last-saved',
+                xml: parser.parseFromString( defaultInstanceData, 'text/xml' ),
+            };
+
+            getFormPartsStubResult = {
+                externalData: [
+                    lastSavedExternalData,
+                ],
+                form: form1,
+                model: model1,
+                hash: hash1
+            };
+
+            sandbox.stub( connection, 'getFormParts' ).callsFake( survey => {
+                console.log( 'getFormParts' );
+
+                return formCache.getLastSavedRecord( survey.enketoId )
+                    .then( lastSavedRecord => {
+                        if ( lastSavedRecord != null ) {
+                            return { lastSavedRecord };
+                        }
+
+                        return {};
+                    } )
+                    .then( lastSavedData => {
+                        console.log( 'is enc 4?', encryptor.isEncryptionEnabled( survey ) );
+                        const formParts = Object.assign( {
+                            enketoId: survey.enketoId,
+                        }, getFormPartsStubResult, lastSavedData );
+
+                        if ( encryptor.isEncryptionEnabled( survey ) ) {
+                            return encryptor.setEncryptionEnabled( formParts );
+                        }
+
+                        return formParts;
+                    } );
+            } );
+
+            store.init().then( done, done );
+        } );
+
+        afterEach( done => {
+            timers.clearTimeout();
+            timers.clearInterval();
+            timers.restore();
+
+            store.survey.removeAll().then( done, done );
+        } );
+
+        it( 'sets the survey\'s last saved record', done => {
+            const originalRecord = Object.assign( {}, record );
+
+            formCache.init( survey )
+                .then( () => {
+                    return formCache.setLastSavedRecord( enketoId, record );
+                } )
+                .then( survey => {
+                    Object.entries( originalRecord ).forEach( ( [ key, value ] ) => {
+                        expect( survey.lastSavedRecord[ key ] ).to.equal( value );
+                    } );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'preserves the last saved record when a form is updated', done => {
+            const originalRecord = Object.assign( {}, record );
+            const update = Object.assign( {}, survey, {
+                hash: '123456',
+                model: `${model1}<!-- updated -->`,
+            } );
+
+            formCache.init( survey )
+                .then( () => {
+                    return formCache.setLastSavedRecord( enketoId, record );
+                } )
+                .then( () => updateSurvey( update ) )
+                .then( survey => {
+                    expect( survey.hash ).to.equal( update.hash );
+                    expect( survey.model ).to.equal( update.model );
+
+                    Object.entries( originalRecord ).forEach( ( [ key, value ] ) => {
+                        expect( survey.lastSavedRecord[ key ] ).to.equal( value );
+                    } );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'updates last-saved externalData when the last saved record is updated', done => {
+            const updatedItemValue = 'populated';
+            const update = Object.assign( {}, record, {
+                xml: `<data id="surveyA"><item>${updatedItemValue}</item><meta><instanceID>uuid:ea3baa91-74b5-4892-af6f-96267f7fe12e</instanceID></meta></data>`,
+            } );
+
+            formCache.init( survey )
+                .then( () => formCache.setLastSavedRecord( enketoId, update ) )
+                .then( () => formCache.get( survey ) )
+                .then( survey => {
+                    expect( Array.isArray( survey.externalData ) ).to.equal( true );
+                    expect( survey.externalData.length ).to.equal( 1 );
+
+                    const data = survey.externalData[0];
+
+                    expect( data.id ).to.equal( lastSavedExternalData.id );
+                    expect( data.src ).to.equal( lastSavedExternalData.src );
+
+                    /** @type {Element} */
+                    const xmlDocument = data.xml.documentElement;
+
+                    const dataItemValue = xmlDocument.querySelector( 'item' ).innerHTML;
+
+                    expect( dataItemValue ).to.equal( updatedItemValue );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'does not set the survey\'s last saved record when encryption is enabled', done => {
+            const encryptedSurvey = encryptor.setEncryptionEnabled( survey );
+
+            const form = { id: 'abc', version: '2', encryptionKey: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5s9p+VdyX1ikG8nnoXLCC9hKfivAp/e1sHr3O15UQ+a8CjR/QV29+cO8zjS/KKgXZiOWvX+gDs2+5k9Kn4eQm5KhoZVw5Xla2PZtJESAd7dM9O5QrqVJ5Ukrq+kG/uV0nf6X8dxyIluNeCK1jE55J5trQMWT2SjDcj+OVoTdNGJ1H6FL+Horz2UqkIObW5/elItYF8zUZcO1meCtGwaPHxAxlvODe8JdKs3eMiIo9eTT4WbH1X+7nJ21E/FBd8EmnK/91UGOx2AayNxM0RN7pAcj47a434LzeM+XCnBztd+mtt1PSflF2CFE116ikEgLcXCj4aklfoON9TwDIQSp0wIDAQAB' };
+
+            formCache.init( encryptedSurvey )
+                .then( () => encryptor.encryptRecord( form, record ) )
+                .then( encryptedRecord => {
+                    return formCache.setLastSavedRecord( enketoId, encryptedRecord );
+                } )
+                .then( survey => {
+                    expect( survey.lastSavedRecord ).to.equal( undefined );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'does not set the survey\'s last saved unencrypted draft record when encryption is enabled', done => {
+            encryptor.setEncryptionEnabled( survey );
+
+            record.draft = true;
+
+            formCache.init( survey )
+                .then( () => {
+                    return formCache.setLastSavedRecord( enketoId, record );
+                } )
+                .then( survey => {
+                    expect( survey.lastSavedRecord ).to.equal( undefined );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'does not set the survey\'s last saved record when the model does not populate a last-saved secondary instance', done => {
+            getFormPartsStubResult = Object.assign( {}, getFormPartsStubResult, {
+                externalData: [],
+            } );
+
+            formCache.init( survey )
+                .then( () => {
+                    return formCache.setLastSavedRecord( enketoId, record );
+                } )
+                .then( survey => {
+                    expect( survey.lastSavedRecord ).to.equal( undefined );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'removes the survey\'s last saved record when the model no longer populates a last-saved secondary instance', done => {
+            const update = Object.assign( {}, survey, {
+                hash: '123456',
+                model: `${model1}<!-- updated -->`,
+                externalData: [],
+            } );
+
+            formCache.init( survey )
+                .then( () => {
+                    return formCache.setLastSavedRecord( enketoId, record );
+                } )
+                .then( () => updateSurvey( update ) )
+                .then( survey => {
+                    expect( survey.lastSavedRecord ).to.equal( undefined );
+                } )
+                .then( done, done );
+
+        } );
+
+        it( 'gets the survey\'s last saved record', done => {
+            const originalRecord = Object.assign( {}, record );
+
+            formCache.init( survey )
+                .then( survey => {
+                    return formCache.setLastSavedRecord( survey.enketoId, record );
+                } )
+                .then( survey => {
+                    return formCache.getLastSavedRecord( survey.enketoId );
+                } )
+                .then( lastSavedRecord => {
+                    Object.entries( originalRecord ).forEach( ( [ key, value ] ) => {
+                        expect( lastSavedRecord[ key ] ).to.equal( value );
+                    } );
+                } )
+                .then( done, done );
+        } );
     } );
 
     describe( 'storage for offline mode', () => {

--- a/test/client/feature/last-saved.spec.js
+++ b/test/client/feature/last-saved.spec.js
@@ -83,6 +83,13 @@ describe( 'Support for jr://instance/last-saved endpoint', () => {
             openRosaId: 'formA',
             openRosaServer: 'http://localhost:3000',
             enketoId: enketoIdA,
+            externalData: [
+                {
+                    id: 'last-saved',
+                    src: 'jr://instance/last-saved',
+                    xml: '<data id="modelA"><foo/></data>',
+                },
+            ],
             theme: '',
             form: `<form class="or"><img src="/path/to/${enketoIdA}.jpg"/></form>`,
             model: '<model><foo/></model>',
@@ -93,6 +100,13 @@ describe( 'Support for jr://instance/last-saved endpoint', () => {
             openRosaId: 'formB',
             openRosaServer: 'http://localhost:3000',
             enketoId: enketoIdB,
+            externalData: [
+                {
+                    id: 'last-saved',
+                    src: 'jr://instance/last-saved',
+                    xml: '<data id="modelB"><foo/></data>',
+                },
+            ],
             theme: '',
             form: `<form class="or"><img src="/path/to/${enketoIdB}.jpg"/></form>`,
             model: '<model><bar/></model>',

--- a/test/client/feature/survey-encryption.spec.js
+++ b/test/client/feature/survey-encryption.spec.js
@@ -1,0 +1,169 @@
+/**
+ * @module survey-encryption.spec.js
+ * @description Tests functionality around encryption-enabled surveys
+ * @see {ConnectionSpec}
+ * @see {EncryptorSpec}
+ * @see {LastSavedFeatureSpec}
+ */
+
+import encryptor from '../../../public/js/src/module/encryptor';
+import formCache from '../../../public/js/src/module/form-cache';
+import records from '../../../public/js/src/module/records-queue';
+import settings from '../../../public/js/src/module/settings';
+import store from '../../../public/js/src/module/store';
+
+/**
+ * @typedef {import('../connection.spec.js')} ConnectionSpec
+ */
+
+/**
+ * @typedef {import('../encryptor.spec.js')} EncryptorSpec
+ */
+
+/**
+ * @typedef {import('./last-saved.spec.js')} LastSavedFeatureSpec
+ */
+
+/**
+ * @typedef {import('../../../app/models/survey-model').SurveyObject} Survey
+ */
+
+describe( 'Encryption-enabled surveys', () => {
+    const enketoId = 'surveyA';
+
+    /** @type { SinonSandbox } */
+    let sandbox;
+
+    /** @type {Survey} */
+    let survey;
+
+    beforeEach( done => {
+        sandbox = sinon.createSandbox();
+        sandbox.stub( settings, 'enketoId' ).get( () => enketoId );
+
+        survey = {
+            openRosaId: 'formA',
+            openRosaServer: 'http://localhost:3000',
+            enketoId,
+            theme: '',
+            form: `<form class="or"><img src="/path/to/${enketoId}.jpg"/></form>`,
+            model: '<model><foo/></model>',
+            hash: '12345',
+        };
+
+        store.init().then( () => done(), done );
+    } );
+
+    afterEach( done => {
+        sandbox.restore();
+
+        Promise.all( [
+            store.record.removeAll(),
+            store.survey.removeAll(),
+        ] ).then( () => done(), done );
+    } );
+
+    describe( 'runtime state', () => {
+        it( 'is not enabled by default', () => {
+            expect( encryptor.isEncryptionEnabled( survey ) ).to.equal( false );
+        } );
+
+        it( 'is enabled when set', () => {
+            const result = encryptor.setEncryptionEnabled( survey );
+
+            expect( encryptor.isEncryptionEnabled( result ) ).to.equal( true );
+        } );
+    } );
+
+    describe( 'client storage', () => {
+        it( 'creates an encryption-enabled survey', done => {
+            const encryptedSurvey = encryptor.setEncryptionEnabled( survey );
+
+            store.survey.set( encryptedSurvey )
+                .then( result => {
+                    expect( encryptor.isEncryptionEnabled( result ) ).to.equal( true );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'gets an encryption-enabled survey', done => {
+            const encryptedSurvey = encryptor.setEncryptionEnabled( survey );
+
+            store.survey.set( encryptedSurvey )
+                .then( () => store.survey.get( survey.enketoId ) )
+                .then( result => {
+                    expect( encryptor.isEncryptionEnabled( result ) ).to.equal( true );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'updates an encryption-enabled survey', done => {
+            const encryptedSurvey = encryptor.setEncryptionEnabled( survey );
+            const model = '<model><updated/></model>';
+            const update = Object.assign( encryptedSurvey, {
+                model,
+            } );
+
+            store.survey.set( encryptedSurvey )
+                .then( () => {
+                    return store.survey.update( update );
+                } )
+                .then( result => {
+                    expect( encryptor.isEncryptionEnabled( result ) ).to.equal( true );
+                    expect( result.model ).to.equal( model );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'does not create a last-saved record when creating a record for an encrypted survey', done => {
+            const form = { id: 'abc', version: '2', encryptionKey: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5s9p+VdyX1ikG8nnoXLCC9hKfivAp/e1sHr3O15UQ+a8CjR/QV29+cO8zjS/KKgXZiOWvX+gDs2+5k9Kn4eQm5KhoZVw5Xla2PZtJESAd7dM9O5QrqVJ5Ukrq+kG/uV0nf6X8dxyIluNeCK1jE55J5trQMWT2SjDcj+OVoTdNGJ1H6FL+Horz2UqkIObW5/elItYF8zUZcO1meCtGwaPHxAxlvODe8JdKs3eMiIo9eTT4WbH1X+7nJ21E/FBd8EmnK/91UGOx2AayNxM0RN7pAcj47a434LzeM+XCnBztd+mtt1PSflF2CFE116ikEgLcXCj4aklfoON9TwDIQSp0wIDAQAB' };
+
+            const survey = encryptor.setEncryptionEnabled( {
+                openRosaId: 'formC',
+                openRosaServer: 'http://localhost:3000',
+                enketoId,
+                theme: '',
+                form: `<form class="or"><img src="/path/to/${enketoId}.jpg"/></form>`,
+                model: '<model><foo/></model>',
+                hash: '12345',
+            } );
+            const recordA = {
+                draft: false,
+                enketoId,
+                files: [],
+                instanceId: 'a',
+                name: 'name A',
+                xml: '<model><something>a</something></model>',
+            };
+            const recordB = {
+                draft: true,
+                enketoId,
+                files: [],
+                instanceId: 'b',
+                name: 'name B',
+                xml: '<model><something>b</something></model>',
+            };
+
+            records.init()
+                .then( () => store.survey.set( survey ) )
+                .then( () => encryptor.encryptRecord( form, recordA ) )
+                .then( encryptedRecordA => {
+                    return records.save( 'set', encryptedRecordA );
+                } )
+                .then( () => {
+                    return formCache.getLastSavedRecord( enketoId );
+                } )
+                .then( () => encryptor.encryptRecord( form, recordB ) )
+                .then( encryptedRecordB => {
+                    return records.save( 'set', encryptedRecordB );
+                } )
+                .then( () => {
+                    return formCache.getLastSavedRecord( enketoId );
+                } )
+                .then( record => {
+                    expect( record ).to.equal( undefined );
+                } )
+                .then( done, done );
+        } );
+    } );
+} );

--- a/test/client/form-cache.spec.js
+++ b/test/client/form-cache.spec.js
@@ -2,6 +2,19 @@ import encryptor from '../../public/js/src/module/encryptor';
 import formCache from '../../public/js/src/module/form-cache';
 import connection from '../../public/js/src/module/connection';
 import store from '../../public/js/src/module/store';
+import settings from '../../public/js/src/module/settings';
+
+/**
+ * @typedef { import('sinon').SinonSandbox } SinonSandbox
+ */
+
+/**
+ * @typedef { import('sinon').SinonFakeTimers } SinonFakeTimers
+ */
+
+/**
+ * @typedef { import('sinon').SinonStub } SinonStub
+ */
 
 /**
  * @typedef {import('../../app/models/record-model').EnketoRecord} EnketoRecord
@@ -17,17 +30,43 @@ const model1 = '<model/>';
 const hash1 = '12345';
 
 describe( 'Client Form Cache', () => {
-    let survey, sandbox, getFormPartsSpy, getFileSpy;
+    /** @type {Survey} */
+    let survey;
+
+    /** @type {SinonSandbox} */
+    let sandbox;
+
+    /** @type {SinonStub} */
+    let getFormPartsSpy;
+
+    /** @type {SinonStub} */
+    let getFileSpy;
+
+    /** @type {SinonFakeTimers} */
+    let timers;
 
     beforeEach( done => {
         survey = {};
         sandbox = sinon.createSandbox();
-        getFormPartsSpy = sandbox.stub( connection, 'getFormParts' ).callsFake( survey => Promise.resolve( {
-            enketoId: survey.enketoId,
-            form: form1,
-            model: model1,
-            hash: hash1
-        } ) );
+
+        // Prevent calls to `_updateCache` after tests complete/stubs are restored
+        timers = sinon.useFakeTimers();
+
+        getFormPartsSpy = sandbox.stub( connection, 'getFormParts' ).callsFake( survey => {
+            let result = {
+                enketoId: survey.enketoId,
+                form: form1,
+                model: model1,
+                hash: hash1
+            };
+
+            if ( encryptor.isEncryptionEnabled( survey ) ) {
+                result = encryptor.setEncryptionEnabled( result );
+            }
+
+            return Promise.resolve( result );
+        } );
+
         getFileSpy = sandbox.stub( connection, 'getMediaFile' ).callsFake( url => Promise.resolve( {
             url,
             item: new Blob( [ 'babdf' ], {
@@ -40,6 +79,7 @@ describe( 'Client Form Cache', () => {
 
     afterEach( done => {
         sandbox.restore();
+        timers.restore();
 
         store.survey.removeAll().then( done, done );
     } );
@@ -108,9 +148,6 @@ describe( 'Client Form Cache', () => {
         /** @type {EnketoRecord} */
         let record;
 
-        /** @type {Survey} */
-        let survey;
-
         beforeEach( done => {
             record = {
                 draft: false,
@@ -126,6 +163,8 @@ describe( 'Client Form Cache', () => {
                 enketoId,
                 theme: '',
             };
+
+            sandbox.stub( settings, 'enketoId' ).get( () => survey.enketoId );
 
             store.init().then( done, done );
         } );
@@ -149,17 +188,30 @@ describe( 'Client Form Cache', () => {
                 .then( done, done );
         } );
 
-        it( 'does not set the survey\'s last saved record when encrypted', done => {
-            /**
-             * @param { Record } record - the record to encrypt
-             * @return { Promise<Record> } - the encrypted record
-             */
+        it( 'does not set the survey\'s last saved record when encryption is enabled', done => {
+            encryptor.setEncryptionEnabled( survey );
+
             const form = { id: 'abc', version: '2', encryptionKey: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5s9p+VdyX1ikG8nnoXLCC9hKfivAp/e1sHr3O15UQ+a8CjR/QV29+cO8zjS/KKgXZiOWvX+gDs2+5k9Kn4eQm5KhoZVw5Xla2PZtJESAd7dM9O5QrqVJ5Ukrq+kG/uV0nf6X8dxyIluNeCK1jE55J5trQMWT2SjDcj+OVoTdNGJ1H6FL+Horz2UqkIObW5/elItYF8zUZcO1meCtGwaPHxAxlvODe8JdKs3eMiIo9eTT4WbH1X+7nJ21E/FBd8EmnK/91UGOx2AayNxM0RN7pAcj47a434LzeM+XCnBztd+mtt1PSflF2CFE116ikEgLcXCj4aklfoON9TwDIQSp0wIDAQAB' };
 
             formCache.init( survey )
                 .then( () => encryptor.encryptRecord( form, record ) )
                 .then( encryptedRecord => {
                     return formCache.setLastSavedRecord( enketoId, encryptedRecord );
+                } )
+                .then( survey => {
+                    expect( survey.lastSavedRecord ).to.equal( undefined );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'does not set the survey\'s last saved unencrypted draft record when encryption is enabled', done => {
+            encryptor.setEncryptionEnabled( survey );
+
+            record.draft = true;
+
+            formCache.init( survey )
+                .then( () => {
+                    return formCache.setLastSavedRecord( enketoId, record );
                 } )
                 .then( survey => {
                     expect( survey.lastSavedRecord ).to.equal( undefined );

--- a/test/client/form-cache.spec.js
+++ b/test/client/form-cache.spec.js
@@ -1,3 +1,4 @@
+import encryptor from '../../public/js/src/module/encryptor';
 import formCache from '../../public/js/src/module/form-cache';
 import connection from '../../public/js/src/module/connection';
 import store from '../../public/js/src/module/store';
@@ -144,6 +145,24 @@ describe( 'Client Form Cache', () => {
                     Object.entries( originalRecord ).forEach( ( [ key, value ] ) => {
                         expect( survey.lastSavedRecord[ key ] ).to.equal( value );
                     } );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'does not set the survey\'s last saved record when encrypted', done => {
+            /**
+             * @param { Record } record - the record to encrypt
+             * @return { Promise<Record> } - the encrypted record
+             */
+            const form = { id: 'abc', version: '2', encryptionKey: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5s9p+VdyX1ikG8nnoXLCC9hKfivAp/e1sHr3O15UQ+a8CjR/QV29+cO8zjS/KKgXZiOWvX+gDs2+5k9Kn4eQm5KhoZVw5Xla2PZtJESAd7dM9O5QrqVJ5Ukrq+kG/uV0nf6X8dxyIluNeCK1jE55J5trQMWT2SjDcj+OVoTdNGJ1H6FL+Horz2UqkIObW5/elItYF8zUZcO1meCtGwaPHxAxlvODe8JdKs3eMiIo9eTT4WbH1X+7nJ21E/FBd8EmnK/91UGOx2AayNxM0RN7pAcj47a434LzeM+XCnBztd+mtt1PSflF2CFE116ikEgLcXCj4aklfoON9TwDIQSp0wIDAQAB' };
+
+            formCache.init( survey )
+                .then( () => encryptor.encryptRecord( form, record ) )
+                .then( encryptedRecord => {
+                    return formCache.setLastSavedRecord( enketoId, encryptedRecord );
+                } )
+                .then( survey => {
+                    expect( survey.lastSavedRecord ).to.equal( undefined );
                 } )
                 .then( done, done );
         } );

--- a/test/client/records-queue.spec.js
+++ b/test/client/records-queue.spec.js
@@ -1,6 +1,5 @@
 import connection from '../../public/js/src/module/connection';
 import encryptor from '../../public/js/src/module/encryptor';
-import exporter from '../../public/js/src/module/exporter';
 import formCache from '../../public/js/src/module/form-cache';
 import records from '../../public/js/src/module/records-queue';
 import settings from '../../public/js/src/module/settings';

--- a/test/client/records-queue.spec.js
+++ b/test/client/records-queue.spec.js
@@ -469,7 +469,7 @@ describe( 'Records queue', () => {
     } );
 
     describe( 'Uploading records', () => {
-        it( 'uploads queued records, excluding auto-saved/last-saved and draft records', done => {
+        it( 'uploads queued records, excluding auto-saved and draft records', done => {
             const autoSavedKey = records.getAutoSavedKey();
 
             const expectedUploadedData = [

--- a/test/client/records-queue.spec.js
+++ b/test/client/records-queue.spec.js
@@ -1,0 +1,526 @@
+import connection from '../../public/js/src/module/connection';
+import encryptor from '../../public/js/src/module/encryptor';
+import exporter from '../../public/js/src/module/exporter';
+import formCache from '../../public/js/src/module/form-cache';
+import records from '../../public/js/src/module/records-queue';
+import settings from '../../public/js/src/module/settings';
+import store from '../../public/js/src/module/store';
+
+/**
+ * @typedef {import('../../app/models/record-model').EnketoRecord} EnketoRecord
+ */
+
+/**
+ * @typedef {import('../../app/models/survey-model').SurveyObject} Survey
+ */
+
+/**
+ * @typedef SinonSandbox { import('sinon').SinonSandbox }
+ */
+
+/**
+ * While some of this is tested in store.spec.js, this suite tests the additional
+ * logic performed in records-queue.js functionality around the client store.
+ */
+describe( 'Records queue', () => {
+    const enketoIdA = 'surveyA';
+    const instanceIdA = 'recordA';
+    const enketoIdB = 'surveyB';
+    const instanceIdB = 'recordB';
+
+    /** @type {string} */
+    let autoSavedKey;
+
+    /** @type { string } */
+    let enketoId;
+
+    /** @type { SinonSandbox } */
+    let sandbox;
+
+    /** @type { Survey } */
+    let surveyA;
+
+    /** @type { Survey } */
+    let surveyB;
+
+    /** @type { EnketoRecord } */
+    let recordA;
+
+    /** @type { EnketoRecord } */
+    let recordB;
+
+    /** @type { File[] } */
+    let files;
+
+    beforeEach( done => {
+        enketoId = enketoIdA;
+
+        sandbox = sinon.createSandbox();
+        sandbox.stub( settings, 'enketoId' ).get( () => enketoId );
+
+        autoSavedKey = records.getAutoSavedKey();
+
+        surveyA = {
+            openRosaId: 'formA',
+            openRosaServer: 'http://localhost:3000',
+            enketoId: enketoIdA,
+            theme: '',
+            form: `<form class="or"><img src="/path/to/${enketoIdA}.jpg"/></form>`,
+            model: '<model><foo/></model>',
+            hash: '12345',
+        };
+
+        surveyB = {
+            openRosaId: 'formB',
+            openRosaServer: 'http://localhost:3000',
+            enketoId: enketoIdB,
+            theme: '',
+            form: `<form class="or"><img src="/path/to/${enketoIdB}.jpg"/></form>`,
+            model: '<model><bar/></model>',
+            hash: '67890',
+        };
+
+        recordA = {
+            draft: false,
+            enketoId,
+            files: [],
+            instanceId: instanceIdA,
+            name: 'name A',
+            xml: '<model><something>a</something></model>',
+        };
+
+        recordB = {
+            draft: false,
+            enketoId,
+            files: [],
+            instanceId: 'b',
+            name: 'name B',
+            xml: '<model><something>b</something></model>',
+        };
+
+        files = [
+            {
+                name: 'something1.xml',
+                item: new Blob( [ '<html>something1</html>' ], {
+                    type: 'text/xml'
+                } )
+            },
+            {
+                name: 'something2.xml',
+                item: new Blob( [ '<html>something2</html>' ], {
+                    type: 'text/xml'
+                } )
+            }
+        ];
+
+        store.init()
+            .then( records.init )
+            .then( () => store.record.set( {
+                draft: true,
+                instanceId: autoSavedKey,
+                enketoId,
+                name: `__autoSave_${Date.now()}`,
+                xml: '<model><autosaved/></model>',
+                files: [],
+            } ) )
+            .then( () => store.survey.set( surveyA ) )
+            .then( () => store.survey.set( surveyB ) )
+            .then( () => done(), done );
+    } );
+
+    afterEach( done => {
+        sandbox.restore();
+
+        Promise.all( [
+            store.property.removeAll(),
+            store.record.removeAll(),
+            store.survey.removeAll(),
+        ] )
+            .then( () => done(), done );
+    } );
+
+    describe( 'storing records', () => {
+        it( 'creates a record', done => {
+            const originalRecord = Object.assign( {}, recordA );
+
+            records.save( 'set', recordA )
+                .then( () => {
+                    return store.record.get( instanceIdA );
+                } )
+                .then( record => {
+                    Object.entries( originalRecord ).forEach( ( [ key, value ] ) => {
+                        expect( record[key] ).to.deep.equal( value );
+                    } );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'updates an autosave draft record with files', done => {
+            recordA.files = files.slice();
+
+            records.updateAutoSavedRecord( recordA )
+                .then( () => {
+                    return records.getAutoSavedRecord();
+                } )
+                .then( record => {
+                    expect( record.draft ).to.equal( true );
+                    expect( record.xml ).to.equal( record.xml );
+                    expect( record.files.length ).to.equal( files.length );
+
+                    for ( const [ index, file ] of files.entries() ) {
+                        const updated = record.files[index];
+
+                        expect( updated.name ).to.equal( file.name );
+                        expect( updated.item ).to.to.be.an.instanceof( Blob );
+                    }
+                } )
+                .then( done, done );
+        } );
+
+        it( 'creates a record with the current autosaved record\'s files', done => {
+            const autoSavedUpdate = Object.assign( {}, recordA, {
+                files: files.slice(),
+            } );
+
+            records.updateAutoSavedRecord( autoSavedUpdate )
+                .then( () => {
+                    return records.save( 'set', recordA );
+                } )
+                .then( () => {
+                    return store.record.get( instanceIdA );
+                } )
+                .then( record => {
+                    expect( record.files.length ).to.equal( files.length );
+
+                    for ( const [ index, file ] of files.entries() ) {
+                        const updated = record.files[index];
+
+                        expect( updated.name ).to.equal( file.name );
+                        expect( updated.item ).to.to.be.an.instanceof( Blob );
+                    }
+                } )
+                .then( done, done );
+        } );
+
+        it( 'updates a record', done => {
+            const update = {
+                draft: false,
+                enketoId,
+                instanceId: instanceIdA,
+                name: 'name A updated',
+                xml: '<model><updated/></model>'
+            };
+            const payload = Object.assign( {}, update );
+
+            records.save( 'set', recordA )
+                .then( () => {
+                    return records.save( 'update', payload );
+                } )
+                .then( () => {
+                    return store.record.get( instanceIdA );
+                } )
+                .then( record => {
+                    Object.entries( update ).forEach( ( [ key, value ] ) => {
+                        expect( record[key] ).to.deep.equal( value );
+                    } );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'creates a last-saved record when creating a record', done => {
+            const originalRecord = Object.assign( {}, recordA );
+
+            records.save( 'set', recordA )
+                .then( () => {
+                    return formCache.getLastSavedRecord( enketoId );
+                } )
+                .then( record => {
+                    Object.entries( originalRecord ).forEach( ( [ key, value ] ) => {
+                        expect( record[key] ).to.deep.equal( value );
+                    } );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'replaces a last-saved record when creating a newer record', done => {
+            const originalRecord = Object.assign( {}, recordA );
+
+            records.save( 'set', recordB )
+                .then( () => {
+                    return records.save( 'set', recordA );
+                } )
+                .then( () => {
+                    return formCache.getLastSavedRecord( enketoId );
+                } )
+                .then( record => {
+                    Object.entries( originalRecord ).forEach( ( [ key, value ] ) => {
+                        expect( record[key] ).to.deep.equal( value );
+                    } );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'creates a last-saved record when updating a record', done => {
+            const originalSurvey = Object.assign( {}, surveyA );
+
+            const update = {
+                draft: false,
+                enketoId,
+                instanceId: instanceIdA,
+                name: 'name A updated',
+                xml: '<model><updated/></model>'
+            };
+            const payload = Object.assign( {}, update );
+
+            records.save( 'set', recordA )
+                .then( () => {
+                    // This would be the condition in cases where a record already
+                    // existed before this feature was implemented
+                    return store.survey.update( originalSurvey );
+                } )
+                .then( () => {
+                    return records.save( 'update', update );
+                } )
+                .then( () => {
+                    return formCache.getLastSavedRecord( enketoId );
+                } )
+                .then( record => {
+                    Object.entries( payload ).forEach( ( [ key, value ] ) => {
+                        expect( record[key] ).to.deep.equal( value );
+                    } );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'replaces a last-saved record when updating a record', done => {
+            const update = {
+                draft: false,
+                enketoId,
+                instanceId: instanceIdA,
+                name: 'name A updated',
+                xml: '<model><updated/></model>'
+            };
+            const payload = Object.assign( {}, update );
+
+            records.save( 'set', recordA )
+                .then( () => {
+                    return records.save( 'update', update );
+                } )
+                .then( () => {
+                    return formCache.getLastSavedRecord( enketoId );
+                } )
+                .then( record => {
+                    Object.entries( payload ).forEach( ( [ key, value ] ) => {
+                        expect( record[key] ).to.deep.equal( value );
+                    } );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'creates separate last-saved records for different forms', done => {
+            const originalRecordA = Object.assign( {}, recordA );
+
+            /** @type { EnketoRecord } */
+            const recordB = {
+                draft: false,
+                enketoId: enketoIdB,
+                instanceId: instanceIdB,
+                name: 'name B',
+                xml: '<model><something>b</something></model>'
+            };
+
+            const originalRecordB = Object.assign( {}, recordB );
+
+            // Create record/last-saved for first form id
+            records.save( 'set', recordA )
+                // Create autosave record for second form id
+                .then( () => {
+                    enketoId = enketoIdB;
+
+                    return store.record.set( {
+                        draft: true,
+                        instanceId: records.getAutoSavedKey(),
+                        enketoId,
+                        name: `__autoSave_${Date.now()}`,
+                        xml: '<model><autosaved/></model>',
+                        files: [],
+                    } );
+                } )
+                // Create record/last-saved for second form id
+                .then( () => {
+                    return records.save( 'set', recordB );
+                } )
+                // Get last-saved record for second form id
+                .then( () => {
+                    return formCache.getLastSavedRecord( enketoId );
+                } )
+                // Validate last-saved record for second form id
+                .then( lastSavedB => {
+                    Object.entries( originalRecordB ).forEach( ( [ key, value ] ) => {
+                        expect( lastSavedB[key] ).to.deep.equal( value );
+                    } );
+                } )
+                // Get last-saved record for first form id
+                .then( () => {
+                    enketoId = enketoIdA;
+
+                    return formCache.getLastSavedRecord( enketoId );
+                } )
+                // Validate last-saved record for first form id has not changed
+                .then( lastSavedA => {
+                    Object.entries( originalRecordA ).forEach( ( [ key, value ] ) => {
+                        expect( lastSavedA[key] ).to.deep.equal( value );
+                    } );
+                } )
+                .then( done, done );
+        } );
+    } );
+
+    describe( 'Encryption', () => {
+        it( 'does not create a last-saved record when creating a record for an encrypted survey', done => {
+            enketoId = 'enketoIdC';
+
+            const form = { id: 'abc', version: '2', encryptionKey: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5s9p+VdyX1ikG8nnoXLCC9hKfivAp/e1sHr3O15UQ+a8CjR/QV29+cO8zjS/KKgXZiOWvX+gDs2+5k9Kn4eQm5KhoZVw5Xla2PZtJESAd7dM9O5QrqVJ5Ukrq+kG/uV0nf6X8dxyIluNeCK1jE55J5trQMWT2SjDcj+OVoTdNGJ1H6FL+Horz2UqkIObW5/elItYF8zUZcO1meCtGwaPHxAxlvODe8JdKs3eMiIo9eTT4WbH1X+7nJ21E/FBd8EmnK/91UGOx2AayNxM0RN7pAcj47a434LzeM+XCnBztd+mtt1PSflF2CFE116ikEgLcXCj4aklfoON9TwDIQSp0wIDAQAB' };
+
+            const survey = encryptor.setEncryptionEnabled( {
+                openRosaId: 'formC',
+                openRosaServer: 'http://localhost:3000',
+                enketoId,
+                theme: '',
+                form: `<form class="or"><img src="/path/to/${enketoIdA}.jpg"/></form>`,
+                model: '<model><foo/></model>',
+                hash: '12345',
+            } );
+            const recordC = Object.assign( {}, recordA, {
+                enketoId,
+                instanceId: 'recordC',
+            } );
+            const recordD = Object.assign( {}, recordB, {
+                draft: true,
+                enketoId,
+                instanceId: 'recordD',
+            } );
+
+            store.survey.set( survey )
+                .then( () => encryptor.encryptRecord( form, recordC ) )
+                .then( encryptedRecordC => {
+                    return records.save( 'set', encryptedRecordC );
+                } )
+                .then( () => {
+                    return formCache.getLastSavedRecord( enketoId );
+                } )
+                .then( () => encryptor.encryptRecord( form, recordD ) )
+                .then( encryptedRecordD => {
+                    return records.save( 'set', encryptedRecordD );
+                } )
+                .then( () => {
+                    return formCache.getLastSavedRecord( enketoId );
+                } )
+                .then( record => {
+                    expect( record ).to.equal( undefined );
+                } )
+                .then( done, done );
+        } );
+    } );
+
+    describe( 'Retrieving records', () => {
+        it( 'gets the record list, excludes the auto-saved records', done => {
+            const autoSavedKey = records.getAutoSavedKey();
+
+            const expectedRecordData = [
+                Object.assign( {}, recordA ),
+                Object.assign( {}, recordB ),
+            ];
+
+            records.save( 'set', recordA )
+                .then( () => {
+                    return records.save( 'set', recordB );
+                } )
+                .then( () => {
+                    return records.getDisplayableRecordList( enketoId );
+                } )
+                .then( records => {
+                    expect( records.length ).to.equal( expectedRecordData.length );
+
+                    records.forEach( record => {
+                        expect( record.instanceId ).not.to.equal( autoSavedKey );
+                    } );
+
+                    expectedRecordData.forEach( ( recordData, index ) => {
+                        const record = records[index];
+
+                        Object.entries( recordData ).forEach( ( [ key, value ] ) => {
+                            expect( record[key] ).to.deep.equal( value );
+                        } );
+                    } );
+                } )
+                .then( done, done );
+        } );
+
+        // This is primarily testing that an empty array is returned as the db.js
+        // types indicate, rather than needing to keep using falsy checks.
+        it( 'gets an empty record list', done => {
+            records.getDisplayableRecordList( enketoId )
+                .then( records => {
+                    expect( Array.isArray( records ) ).to.equal( true );
+                    expect( records.length ).to.equal( 0 );
+                } )
+                .then( done, done );
+        } );
+    } );
+
+    describe( 'Uploading records', () => {
+        it( 'uploads queued records, excluding auto-saved/last-saved and draft records', done => {
+            const autoSavedKey = records.getAutoSavedKey();
+
+            const expectedUploadedData = [
+                Object.assign( {}, recordA ),
+                Object.assign( {}, recordB ),
+            ];
+
+            sandbox.stub( connection, 'getOnlineStatus' ).callsFake( () => {
+                return Promise.resolve( true );
+            } );
+
+            /** @type { EnketoRecord[] } */
+            let uploaded = [];
+
+            sandbox.stub( connection, 'uploadRecord' ).callsFake( record => {
+                uploaded.push( record );
+            } );
+
+            records.save( 'set', recordA )
+                .then( () => {
+                    return records.save( 'set', recordB );
+                } )
+                .then( () => {
+                    return store.record.set( {
+                        draft: true,
+                        enketoId,
+                        instanceId: 'c',
+                        name: 'name C',
+                        xml: '<model><something>c</something></model>',
+                    } );
+                } )
+                .then( () => {
+                    return records.uploadQueue();
+                } )
+                .then( () => {
+                    expect( uploaded.length ).to.equal( expectedUploadedData.length );
+
+                    uploaded.forEach( record => {
+                        expect( record.instanceId ).not.to.equal( autoSavedKey );
+                    } );
+
+                    expectedUploadedData.forEach( ( recordData, index ) => {
+                        const record = uploaded[index];
+
+                        Object.entries( recordData ).forEach( ( [ key, value ] ) => {
+                            expect( record[key] ).to.deep.equal( value );
+                        } );
+                    } );
+                } )
+                .then( done, done );
+        } );
+    } );
+} );

--- a/test/client/records-queue.spec.js
+++ b/test/client/records-queue.spec.js
@@ -1,9 +1,25 @@
+
+/**
+ * @module records-queue.spec.js
+ * @description While some of this is tested in store.spec.js, this suite tests
+ * the additional logic performed in records-queue.js functionality around the
+ * client store.
+ * @see {LastSavedFeatureSpec}
+ * @see {StoreSpec}
+ */
+
 import connection from '../../public/js/src/module/connection';
-import encryptor from '../../public/js/src/module/encryptor';
-import formCache from '../../public/js/src/module/form-cache';
 import records from '../../public/js/src/module/records-queue';
 import settings from '../../public/js/src/module/settings';
 import store from '../../public/js/src/module/store';
+
+/**
+ * @typedef {import('./feature/last-saved.spec.js')} LastSavedFeatureSpec
+ */
+
+/**
+ * @typedef {import('./store.spec.js')} StoreSpec
+ */
 
 /**
  * @typedef {import('../../app/models/record-model').EnketoRecord} EnketoRecord
@@ -17,15 +33,10 @@ import store from '../../public/js/src/module/store';
  * @typedef SinonSandbox { import('sinon').SinonSandbox }
  */
 
-/**
- * While some of this is tested in store.spec.js, this suite tests the additional
- * logic performed in records-queue.js functionality around the client store.
- */
 describe( 'Records queue', () => {
     const enketoIdA = 'surveyA';
     const instanceIdA = 'recordA';
     const enketoIdB = 'surveyB';
-    const instanceIdB = 'recordB';
 
     /** @type {string} */
     let autoSavedKey;
@@ -226,200 +237,6 @@ describe( 'Records queue', () => {
                 .then( done, done );
         } );
 
-        it( 'creates a last-saved record when creating a record', done => {
-            const originalRecord = Object.assign( {}, recordA );
-
-            records.save( 'set', recordA )
-                .then( () => {
-                    return formCache.getLastSavedRecord( enketoId );
-                } )
-                .then( record => {
-                    Object.entries( originalRecord ).forEach( ( [ key, value ] ) => {
-                        expect( record[key] ).to.deep.equal( value );
-                    } );
-                } )
-                .then( done, done );
-        } );
-
-        it( 'replaces a last-saved record when creating a newer record', done => {
-            const originalRecord = Object.assign( {}, recordA );
-
-            records.save( 'set', recordB )
-                .then( () => {
-                    return records.save( 'set', recordA );
-                } )
-                .then( () => {
-                    return formCache.getLastSavedRecord( enketoId );
-                } )
-                .then( record => {
-                    Object.entries( originalRecord ).forEach( ( [ key, value ] ) => {
-                        expect( record[key] ).to.deep.equal( value );
-                    } );
-                } )
-                .then( done, done );
-        } );
-
-        it( 'creates a last-saved record when updating a record', done => {
-            const originalSurvey = Object.assign( {}, surveyA );
-
-            const update = {
-                draft: false,
-                enketoId,
-                instanceId: instanceIdA,
-                name: 'name A updated',
-                xml: '<model><updated/></model>'
-            };
-            const payload = Object.assign( {}, update );
-
-            records.save( 'set', recordA )
-                .then( () => {
-                    // This would be the condition in cases where a record already
-                    // existed before this feature was implemented
-                    return store.survey.update( originalSurvey );
-                } )
-                .then( () => {
-                    return records.save( 'update', update );
-                } )
-                .then( () => {
-                    return formCache.getLastSavedRecord( enketoId );
-                } )
-                .then( record => {
-                    Object.entries( payload ).forEach( ( [ key, value ] ) => {
-                        expect( record[key] ).to.deep.equal( value );
-                    } );
-                } )
-                .then( done, done );
-        } );
-
-        it( 'replaces a last-saved record when updating a record', done => {
-            const update = {
-                draft: false,
-                enketoId,
-                instanceId: instanceIdA,
-                name: 'name A updated',
-                xml: '<model><updated/></model>'
-            };
-            const payload = Object.assign( {}, update );
-
-            records.save( 'set', recordA )
-                .then( () => {
-                    return records.save( 'update', update );
-                } )
-                .then( () => {
-                    return formCache.getLastSavedRecord( enketoId );
-                } )
-                .then( record => {
-                    Object.entries( payload ).forEach( ( [ key, value ] ) => {
-                        expect( record[key] ).to.deep.equal( value );
-                    } );
-                } )
-                .then( done, done );
-        } );
-
-        it( 'creates separate last-saved records for different forms', done => {
-            const originalRecordA = Object.assign( {}, recordA );
-
-            /** @type { EnketoRecord } */
-            const recordB = {
-                draft: false,
-                enketoId: enketoIdB,
-                instanceId: instanceIdB,
-                name: 'name B',
-                xml: '<model><something>b</something></model>'
-            };
-
-            const originalRecordB = Object.assign( {}, recordB );
-
-            // Create record/last-saved for first form id
-            records.save( 'set', recordA )
-                // Create autosave record for second form id
-                .then( () => {
-                    enketoId = enketoIdB;
-
-                    return store.record.set( {
-                        draft: true,
-                        instanceId: records.getAutoSavedKey(),
-                        enketoId,
-                        name: `__autoSave_${Date.now()}`,
-                        xml: '<model><autosaved/></model>',
-                        files: [],
-                    } );
-                } )
-                // Create record/last-saved for second form id
-                .then( () => {
-                    return records.save( 'set', recordB );
-                } )
-                // Get last-saved record for second form id
-                .then( () => {
-                    return formCache.getLastSavedRecord( enketoId );
-                } )
-                // Validate last-saved record for second form id
-                .then( lastSavedB => {
-                    Object.entries( originalRecordB ).forEach( ( [ key, value ] ) => {
-                        expect( lastSavedB[key] ).to.deep.equal( value );
-                    } );
-                } )
-                // Get last-saved record for first form id
-                .then( () => {
-                    enketoId = enketoIdA;
-
-                    return formCache.getLastSavedRecord( enketoId );
-                } )
-                // Validate last-saved record for first form id has not changed
-                .then( lastSavedA => {
-                    Object.entries( originalRecordA ).forEach( ( [ key, value ] ) => {
-                        expect( lastSavedA[key] ).to.deep.equal( value );
-                    } );
-                } )
-                .then( done, done );
-        } );
-    } );
-
-    describe( 'Encryption', () => {
-        it( 'does not create a last-saved record when creating a record for an encrypted survey', done => {
-            enketoId = 'enketoIdC';
-
-            const form = { id: 'abc', version: '2', encryptionKey: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5s9p+VdyX1ikG8nnoXLCC9hKfivAp/e1sHr3O15UQ+a8CjR/QV29+cO8zjS/KKgXZiOWvX+gDs2+5k9Kn4eQm5KhoZVw5Xla2PZtJESAd7dM9O5QrqVJ5Ukrq+kG/uV0nf6X8dxyIluNeCK1jE55J5trQMWT2SjDcj+OVoTdNGJ1H6FL+Horz2UqkIObW5/elItYF8zUZcO1meCtGwaPHxAxlvODe8JdKs3eMiIo9eTT4WbH1X+7nJ21E/FBd8EmnK/91UGOx2AayNxM0RN7pAcj47a434LzeM+XCnBztd+mtt1PSflF2CFE116ikEgLcXCj4aklfoON9TwDIQSp0wIDAQAB' };
-
-            const survey = encryptor.setEncryptionEnabled( {
-                openRosaId: 'formC',
-                openRosaServer: 'http://localhost:3000',
-                enketoId,
-                theme: '',
-                form: `<form class="or"><img src="/path/to/${enketoIdA}.jpg"/></form>`,
-                model: '<model><foo/></model>',
-                hash: '12345',
-            } );
-            const recordC = Object.assign( {}, recordA, {
-                enketoId,
-                instanceId: 'recordC',
-            } );
-            const recordD = Object.assign( {}, recordB, {
-                draft: true,
-                enketoId,
-                instanceId: 'recordD',
-            } );
-
-            store.survey.set( survey )
-                .then( () => encryptor.encryptRecord( form, recordC ) )
-                .then( encryptedRecordC => {
-                    return records.save( 'set', encryptedRecordC );
-                } )
-                .then( () => {
-                    return formCache.getLastSavedRecord( enketoId );
-                } )
-                .then( () => encryptor.encryptRecord( form, recordD ) )
-                .then( encryptedRecordD => {
-                    return records.save( 'set', encryptedRecordD );
-                } )
-                .then( () => {
-                    return formCache.getLastSavedRecord( enketoId );
-                } )
-                .then( record => {
-                    expect( record ).to.equal( undefined );
-                } )
-                .then( done, done );
-        } );
     } );
 
     describe( 'Retrieving records', () => {

--- a/test/client/store.spec.js
+++ b/test/client/store.spec.js
@@ -1,7 +1,16 @@
+/**
+ * @module store.spec.js
+ * @description Tests client-side data storage logic
+ * @see {SurveyEncryptionSpec}
+ */
+
 // TODO: when chai-as-promised adapter is working, convert these tests using .eventually.
 
-import encryptor from '../../public/js/src/module/encryptor';
 import store from '../../public/js/src/module/store';
+
+/**
+ * @typedef {import('./feature/survey-encryption.spec.js')} SurveyEncryptionSpec
+ */
 
 /**
  * @typedef {import('../../app/models/survey-model').SurveyObject} Survey
@@ -257,16 +266,6 @@ describe( 'Client Storage', () => {
                     done();
                 } );
         } );
-
-        it( 'creates an encryption-enabled survey', done => {
-            const encryptedSurvey = encryptor.setEncryptionEnabled( surveyA );
-
-            store.survey.set( encryptedSurvey )
-                .then( result => {
-                    expect( encryptor.isEncryptionEnabled( result ) ).to.equal( true );
-                } )
-                .then( done, done );
-        } );
     } );
 
     describe( 'getting surveys', () => {
@@ -279,17 +278,6 @@ describe( 'Client Storage', () => {
             store.survey.get( 'nonexisting' )
                 .then( result => {
                     expect( result ).to.equal( undefined );
-                } )
-                .then( done, done );
-        } );
-
-        it( 'gets an encryption-enabled survey', done => {
-            const encryptedSurvey = encryptor.setEncryptionEnabled( surveyA );
-
-            store.survey.set( encryptedSurvey )
-                .then( () => store.survey.get( surveyA.enketoId ) )
-                .then( result => {
-                    expect( encryptor.isEncryptionEnabled( result ) ).to.equal( true );
                 } )
                 .then( done, done );
         } );
@@ -375,24 +363,6 @@ describe( 'Client Storage', () => {
                 .then( result => {
                     // check response of getResource
                     expect( result ).to.equal( undefined );
-                } )
-                .then( done, done );
-        } );
-
-        it( 'updates an encryption-enabled survey', done => {
-            const encryptedSurvey = encryptor.setEncryptionEnabled( surveyA );
-            const model = '<model><updated/></model>';
-            const update = Object.assign( encryptedSurvey, {
-                model,
-            } );
-
-            store.survey.set( encryptedSurvey )
-                .then( () => {
-                    return store.survey.update( update );
-                } )
-                .then( result => {
-                    expect( encryptor.isEncryptionEnabled( result ) ).to.equal( true );
-                    expect( result.model ).to.equal( model );
                 } )
                 .then( done, done );
         } );


### PR DESCRIPTION
Addresses #137.

Moving my progress checklist over here since #258 will only address a subset of this issue.

- [x] Whenever a record is saved to storage save a copy with some __lastSaved key. This makes sure that even successfully submitted records may serve as a source for lastSaved.
  - [x] Offline
  - [x] Online
- [x] Populate a secondary instance with that record 
- [x] Resolve the jr://instance/last-saved URL
- [x] check that this feature is disabled if a form has encryption enabled.
- [x] check that it is not shown in record list
- [x] check that is is not submitted
- [x] check multiple form IDs
- [x] check it is not included in the export of local records

I'll add some additional notes/details inline once the PR is opened.
