### PR TITLE
Fix `d` query parameter decoding twice

### DIFF
--- a/public/js/src/module/settings.js
+++ b/public/js/src/module/settings.js
@@ -35,7 +35,7 @@ for ( const p in queryParams ) {
         // URLs with encoded brackets as well us not-encode brackets will work.
         const matches = decodeURIComponent( p ).match( /d\[(.*)\]/ );
         if ( matches && matches[ 1 ] ) {
-            settings.defaults[ matches[ 1 ] ] = decodeURIComponent( queryParams[ p ] );
+            settings.defaults[ matches[ 1 ] ] = queryParams[ p ];
         }
     }
 }

--- a/public/js/src/module/settings.js
+++ b/public/js/src/module/settings.js
@@ -32,7 +32,7 @@ settings.defaultReturnUrl = config[ 'basePath' ] + DEFAULT_THANKS_URL;
 settings.defaults = {};
 for ( const p in queryParams ) {
     if ( Object.prototype.hasOwnProperty.call( queryParams, p ) ) {
-        // URLs with encoded brackets as well us not-encode brackets will work.
+        // URLs with encoded brackets as well as not-encoded brackets will work.
         const matches = decodeURIComponent( p ).match( /d\[(.*)\]/ );
         if ( matches && matches[ 1 ] ) {
             settings.defaults[ matches[ 1 ] ] = queryParams[ p ];

--- a/test/client/utils.spec.js
+++ b/test/client/utils.spec.js
@@ -222,6 +222,13 @@ describe( 'Client Utilities', () => {
                     '/b/c': 'd and e'
                 }
             }, '?d[%2Fa%2Fb]=c&d[%2Fb%2Fc]=d%20and%20e' ],
+            // handle `%` symbol in value
+            [ {
+                name: 'd',
+                value: {
+                    '/a/b': '10% tax',
+                }
+            }, '?d[%2Fa%2Fb]=10%25%20tax' ],
             // complex combo
             [
                 [ {

--- a/test/server/api-controller.spec.js
+++ b/test/server/api-controller.spec.js
@@ -809,6 +809,17 @@ describe( 'api', () => {
         }, {
             endpoint: '/survey',
             defaults: {
+                '/path/to/node': '10%25 tax',
+            },
+            method: 'post',
+            status: 200,
+            res: {
+                property: 'url',
+                expected: /.+\?d%5B%2Fpath%2Fto%2Fnode%5D=10%25%20tax/
+            }
+        }, {
+            endpoint: '/survey',
+            defaults: {
                 '/path/to/node': '[@]?'
             },
             method: 'post',


### PR DESCRIPTION
## Description

Remove the double call to `decodeURIComponent` and add some tests for encoding of `defaults` at the API endpoint.

## Related Issues

closes #272