### PR TITLE
Fixed: Form preview fails with IDBObjectStore error

### DIFF
--- a/public/js/src/module/connection.js
+++ b/public/js/src/module/connection.js
@@ -355,7 +355,7 @@ function getMaximumSubmissionSize( survey ) {
  * @return { Promise<Survey> } a Promise that resolves with a form parts object
  */
 function getFormParts( props ) {
-    const isEditing = props.instanceId != null;
+    const isLastSavedEnabled = settings.type === 'other';
 
     /** @type {Survey} */
     let survey;
@@ -383,7 +383,7 @@ function getFormParts( props ) {
                 survey = encryptor.setEncryptionEnabled( survey );
             }
 
-            if ( !isEditing ) {
+            if ( isLastSavedEnabled ) {
                 return formCache.getLastSavedRecord( props.enketoId );
             }
         } )

--- a/public/js/src/module/connection.js
+++ b/public/js/src/module/connection.js
@@ -355,8 +355,6 @@ function getMaximumSubmissionSize( survey ) {
  * @return { Promise<Survey> } a Promise that resolves with a form parts object
  */
 function getFormParts( props ) {
-    const isLastSavedEnabled = settings.type === 'other';
-
     /** @type {Survey} */
     let survey;
 
@@ -383,9 +381,7 @@ function getFormParts( props ) {
                 survey = encryptor.setEncryptionEnabled( survey );
             }
 
-            if ( isLastSavedEnabled ) {
-                return formCache.getLastSavedRecord( props.enketoId );
-            }
+            return formCache.getLastSavedRecord( props.enketoId );
         } )
         .then( lastSaved => {
             lastSavedRecord = lastSaved;

--- a/public/js/src/module/form-cache.js
+++ b/public/js/src/module/form-cache.js
@@ -34,7 +34,7 @@ function init( survey ) {
      * Note: it would probably be better if this were in enketo-webform.js, as it
      * doesn't relate to the form cache per se. It's included here for testability.
      */
-    if ( settings.type === 'preview' ) {
+    if ( settings.type !== 'other' ) {
         return connection.getFormParts( survey );
     }
 
@@ -76,6 +76,10 @@ function set( survey ) {
  * @return { Promise<EnketoRecord | undefined> }
  */
 function getLastSavedRecord( enketoId ) {
+    if ( settings.type !== 'other' ) {
+        return Promise.resolve();
+    }
+
     return store.survey.get( enketoId )
         .then( survey => {
             if ( survey != null ) {

--- a/public/js/src/module/form-cache.js
+++ b/public/js/src/module/form-cache.js
@@ -30,6 +30,14 @@ let hash;
  * @return {Promise<Survey>}
  */
 function init( survey ) {
+    /**
+     * Note: it would probably be better if this were in enketo-webform.js, as it
+     * doesn't relate to the form cache per se. It's included here for testability.
+     */
+    if ( settings.type === 'preview' ) {
+        return connection.getFormParts( survey );
+    }
+
     return store.init()
         .then( () => get( survey ) )
         .then( result => {

--- a/test/client/form-cache.spec.js
+++ b/test/client/form-cache.spec.js
@@ -196,12 +196,21 @@ describe( 'Client Form Cache', () => {
 
     } );
 
-    describe( 'previews', () => {
+    describe( 'access types', () => {
+        /** @type {import('sinon').SinonStub} */
+        let getSpy;
+
+        /** @type {import('sinon').SinonStub} */
+        let setSpy;
+
         beforeEach( () => {
-            sandbox.stub( settings, 'type' ).get( () => 'preview' );
+            getSpy = sandbox.stub( store.survey, 'get' );
+            setSpy = sandbox.stub( store.survey, 'set' );
         } );
 
         it( 'bypasses the store when initializing a form in preview mode', done => {
+            sandbox.stub( settings, 'type' ).get( () => 'preview' );
+
             const previewSurvey = {
                 enketoId: null,
                 xformUrl: 'https://xlsform.getodk.org/downloads/b0x0gdti/Range%20test.xml',
@@ -217,6 +226,79 @@ describe( 'Client Form Cache', () => {
                     return getFormPartsSpy.getCall( 0 ).returnValue;
                 } )
                 .then( formParts => {
+                    expect( getSpy.called ).to.equal( false );
+                    expect( setSpy.called ).to.equal( false );
+                    expect( initResult ).to.deep.equal( formParts );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'bypasses the store when initializing a form in single mode', done => {
+            sandbox.stub( settings, 'type' ).get( () => 'single' );
+
+            const singleSurvey = {
+                enketoId: 'surveyA',
+            };
+
+            let initResult;
+
+            formCache.init( singleSurvey )
+                .then( survey => {
+                    initResult = survey;
+
+                    return getFormPartsSpy.getCall( 0 ).returnValue;
+                } )
+                .then( formParts => {
+                    expect( getSpy.called ).to.equal( false );
+                    expect( setSpy.called ).to.equal( false );
+                    expect( initResult ).to.deep.equal( formParts );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'bypasses the store when initializing a form in edit mode', done => {
+            sandbox.stub( settings, 'type' ).get( () => 'edit' );
+
+            const editSurvey = {
+                enketoId: 'surveyA',
+                instanceId: 'instance',
+            };
+
+            let initResult;
+
+            formCache.init( editSurvey )
+                .then( survey => {
+                    initResult = survey;
+
+                    return getFormPartsSpy.getCall( 0 ).returnValue;
+                } )
+                .then( formParts => {
+                    expect( getSpy.called ).to.equal( false );
+                    expect( setSpy.called ).to.equal( false );
+                    expect( initResult ).to.deep.equal( formParts );
+                } )
+                .then( done, done );
+        } );
+
+        it( 'bypasses the store when initializing a form in view mode', done => {
+            sandbox.stub( settings, 'type' ).get( () => 'view' );
+
+            const viewSurvey = {
+                enketoId: 'surveyA',
+                instanceId: 'instance',
+            };
+
+            let initResult;
+
+            formCache.init( viewSurvey )
+                .then( survey => {
+                    initResult = survey;
+
+                    return getFormPartsSpy.getCall( 0 ).returnValue;
+                } )
+                .then( formParts => {
+                    expect( getSpy.called ).to.equal( false );
+                    expect( setSpy.called ).to.equal( false );
                     expect( initResult ).to.deep.equal( formParts );
                 } )
                 .then( done, done );


### PR DESCRIPTION
Fixes #279.

This introduces two changes to fix a regression introduced in #269:

- The store is bypassed in initialization when a form is previewed. As noted in a code comment, this was implemented in form-cache.js primarily to enable testing, but likely more appropriate in enketo-webform.js
- `getFormParts` now only calls `getLastSavedRecord` when `settings.type` is `other`, which is the default value when filling a form (versus `preview`, `single`, `edit`, `view`)