### PR TITLE
Fix: rendering of binary defaults in online-only mode

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,11 @@
         "no-console": ["warn", { "allow": ["error", "deprecate", "warn"] }],
         "eol-last": ["error", "always"],
         "padding-line-between-statements": ["warn", { "blankLine": "always", "prev": "*", "next": "return" }],
-        "space-before-function-paren": ["error", "never"],
+        "space-before-function-paren": ["error", {
+            "anonymous": "never",
+            "async": "always",
+            "named": "never"
+        }],
         "space-in-parens": ["error", "always"],
         "space-infix-ops": "error",
         "array-bracket-spacing": ["error", "always"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,7 +33,7 @@
         "padding-line-between-statements": ["warn", { "blankLine": "always", "prev": "*", "next": "return" }],
         "space-before-function-paren": ["error", {
             "anonymous": "never",
-            "async": "always",
+            "asyncArrow": "always",
             "named": "never"
         }],
         "space-in-parens": ["error", "always"],

--- a/public/js/src/module/connection.js
+++ b/public/js/src/module/connection.js
@@ -56,7 +56,6 @@ import {
 const parser = new DOMParser();
 const xmlSerializer = new XMLSerializer();
 const CONNECTION_URL = `${settings.basePath}/connection`;
-const TRANSFORM_URL = `${settings.basePath}/transform/xform${settings.enketoId ? `/${settings.enketoId}` : ''}`;
 const TRANSFORM_HASH_URL = `${settings.basePath}/transform/xform/hash/${settings.enketoId}`;
 const INSTANCE_URL = ( settings.enketoId ) ? `${settings.basePath}/submission/${settings.enketoId}` : null;
 const MAX_SIZE_URL = ( settings.enketoId ) ? `${settings.basePath}/submission/max-size/${settings.enketoId}` :
@@ -356,6 +355,17 @@ function getMaximumSubmissionSize( survey ) {
 }
 
 /**
+ * @param {string} basePath
+ * @param {string} [enketoId]
+ * @return {string}
+ */
+const getTransformURL = ( basePath, enketoId ) => {
+    const idPath = enketoId ? `/${enketoId}` : '';
+
+    return `${basePath}/transform/xform${idPath}${_getQuery()}`;
+};
+
+/**
  * Obtains HTML Form, XML Model and External Instances
  *
  * @param { GetFormPartsProps } props - form properties object
@@ -365,7 +375,9 @@ function getFormParts( props ) {
     /** @type {Survey} */
     let survey;
 
-    return _postData( TRANSFORM_URL + _getQuery(), {
+    const transformURL = getTransformURL( settings.basePath, props.enketoId );
+
+    return _postData( transformURL, {
         xformUrl: props.xformUrl
     } )
         .then( data => {
@@ -381,16 +393,6 @@ function getFormParts( props ) {
             if ( encryptedSubmission != null ) {
                 survey = encryptor.setEncryptionEnabled( survey );
             }
-
-            const relativeBinaryDefaults = model.querySelectorAll( 'instance > * > *[src^="/"]' );
-
-            relativeBinaryDefaults.forEach( element => {
-                const src = element.getAttribute( 'src' );
-
-                element.setAttribute( 'src', new URL( src, window.location ) );
-            } );
-
-            survey.model = xmlSerializer.serializeToString( model.documentElement );
 
             return _getExternalData( survey, model );
         } )

--- a/test/client/.eslintrc.json
+++ b/test/client/.eslintrc.json
@@ -13,7 +13,7 @@
     "extends": "eslint:recommended",
     "parserOptions": {
         "sourceType": "module",
-        "ecmaVersion": 2015
+        "ecmaVersion": 2020
     },
     "rules": {
         "indent": [ "warn", 4, {


### PR DESCRIPTION
This fixes an issue introduced between [this change](https://github.com/enketo/enketo-express/pull/293/commits/577df16adad277184a7cadbd775a9a542d4e3d3f#diff-acb5beecd107235cca07564ab0a757e51a63149dfa40569bb8f58bb7a4a99a31R393) and [this commit](https://github.com/enketo/enketo-express/pull/293/commits/62943a2459cbf862a6261c6757b34c6cff4dc503) in #293, where once again display of binary defaults was broken. This is a minor change to remove behavior which changed a survey's `model` to use absolute URLs rather than the URLs originally provided to the transformer in the `media` mapping.

The bulk of the rest of this PR is backfilling tests for `getFormParts`. I thought that was more thoroughly tested (and there may be some redundancy with `last-saved.spec.js`), but I didn't feel comfortable writing the relevant test nor making this change without more thorough testing of the function itself.

And, since the regression is present in both 2.8.1 and 3.0.0, we will likely need to patch both. Tomorrow I will also update #291 with the same changes as the regression is present there too.