### PR TITLE
Fix: ensure media labels are loaded when opening a draft in offline mode

### DIFF
--- a/public/js/src/module/controller-webform.js
+++ b/public/js/src/module/controller-webform.js
@@ -197,7 +197,6 @@ function _resetForm( survey, options = {} ) {
 
             const loadErrors = form.init();
 
-            // formreset event will update the form media:
             form.view.html.dispatchEvent( events.FormReset() );
 
             if ( options.isOffline ) {
@@ -217,10 +216,11 @@ function _resetForm( survey, options = {} ) {
 /**
  * Loads a record from storage
  *
- * @param  { string } instanceId - [description]
- * @param  {=boolean?} confirmed -  [description]
+ * @param {Survey} survey
+ * @param {string} instanceId - [description]
+ * @param {=boolean?} confirmed -  [description]
  */
-function _loadRecord( instanceId, confirmed ) {
+function _loadRecord( survey, instanceId, confirmed ) {
     let texts;
     let choices;
     let loadErrors;
@@ -236,7 +236,7 @@ function _loadRecord( instanceId, confirmed ) {
         gui.confirm( texts, choices )
             .then( confirmed => {
                 if ( confirmed ) {
-                    _loadRecord( instanceId, true );
+                    _loadRecord( survey, instanceId, true );
                 }
             } );
     } else {
@@ -254,8 +254,11 @@ function _loadRecord( instanceId, confirmed ) {
                     submitted: false
                 }, formOptions );
                 loadErrors = form.init();
-                // formreset event will update the form media:
+
                 form.view.html.dispatchEvent( events.FormReset() );
+
+                formCache.updateMedia( survey );
+
                 form.recordName = record.name;
                 records.setActive( record.instanceId );
 
@@ -662,7 +665,7 @@ function _setEventHandlers( survey ) {
     } );
 
     $doc.on( 'click', '.record-list__records__record[data-draft="true"]', function() {
-        _loadRecord( $( this ).attr( 'data-id' ), false );
+        _loadRecord( survey, $( this ).attr( 'data-id' ), false );
     } );
 
     $doc.on( 'click', '.record-list__records__record', function() {


### PR DESCRIPTION
Manually verified, there are no tests of controller-webform.js and it has the same testing challenges as enketo-webform\*