### PR TITLE
Fix: restore population of deprecatedID in edit mode

### DIFF
--- a/public/js/src/module/controller-webform.js
+++ b/public/js/src/module/controller-webform.js
@@ -41,6 +41,7 @@ const formOptions = {
  * @property {Document[]} external
  * @property {Survey} survey
  * @property {InstanceAttachment[]} [instanceAttachments]
+ * @property {boolean} [isEditing]
  */
 
 /**
@@ -60,10 +61,7 @@ function init( formEl, data, loadErrors = [] ) {
                 data.instanceStr = record.xml;
             }
 
-            if ( !record || record.draft ) {
-                // Make sure that Enketo Core won't do the instanceID --> deprecatedID move
-                data.submitted = false;
-            }
+            data.submitted = Boolean( data.isEditing );
 
             if ( data.instanceAttachments ) {
                 fileManager.setInstanceAttachments( data.instanceAttachments );


### PR DESCRIPTION
This was a regression in #321: `record` here is populated by `_checkAutoSavedRecord`, which is only available in offline mode. Since that will always be falsey (undefined) in edit mode, `submitted` would be set to false. Since we should only set `deprecatedID` when editing submissions, it made more sense to assign it directly based on the `isEditing` property introduced in #269 (which should also have been added to the JSDoc type at that time).