### PR TITLE
Fix: ensure dynamic manifest URLs are mapped

### DIFF
--- a/app/controllers/transformation-controller.js
+++ b/app/controllers/transformation-controller.js
@@ -13,7 +13,7 @@ const utils = require( '../lib/utils' );
 const routerUtils = require( '../lib/router-utils' );
 const express = require( 'express' );
 const url = require( 'url' );
-const { toMediaMap } = require( '../lib/url' );
+const { replaceMediaSources } = require( '../lib/url' );
 
 const router = express.Router();
 
@@ -107,13 +107,7 @@ function getSurveyHash( req, res, next ) {
 function _getFormDirectly( survey ) {
     return communicator.getXForm( survey )
         .then( communicator.getManifest )
-        .then( xform => {
-            const survey = Object.assign( {}, xform, {
-                media: toMediaMap( xform.manifest ),
-            } );
-
-            return transformer.transform( survey );
-        } );
+        .then( transformer.transform );
 }
 
 /**
@@ -144,8 +138,8 @@ function _getFormFromCache( survey ) {
 function _updateCache( survey ) {
     return communicator.getXFormInfo( survey )
         .then( communicator.getManifest )
-        .then( cacheModel.check )
-        .then( upToDate => {
+        .then( survey => Promise.all( [ survey, cacheModel.check( survey ) ] ) )
+        .then( ( [ survey, upToDate ] ) => {
             if ( !upToDate ) {
                 delete survey.xform;
                 delete survey.form;
@@ -220,6 +214,8 @@ function _checkQuota( survey ) {
  */
 function _respond( res, survey ) {
     delete survey.credentials;
+
+    survey = replaceMediaSources( survey );
 
     res.status( 200 );
     res.send( {

--- a/app/lib/url.js
+++ b/app/lib/url.js
@@ -1,6 +1,36 @@
 const config = require( '../models/config-model' ).server;
 const transformer = require( 'enketo-transformer' );
 
+const markupEntities = {
+    '<': '&lt;',
+    '>': '&gt;',
+    '&': '&amp;',
+    '"': '&quot;',
+};
+
+/**
+ * Escapes HTML and XML special characters, ensuring URLs are safe to insert into
+ * a Survey's HTML form and XML model. Note: this is technically incorrect (as is
+ * the MDN documentation for reserved HTML entities), as it does not include
+ * single-quote characters. But this matches the current behavior in enketo-transformer
+ * (which is the default behavior of libxmljs). This is probably safe, as transformer
+ * will not serialize attribute values to single quotes.
+ *
+ * @see {https://developer.mozilla.org/en-US/docs/Glossary/Entity}
+ * @see {https://developer.mozilla.org/en-US/docs/Web/XML/XML_introduction#entities}
+ * @param {string} value
+ * @return {string}
+ */
+const escapeMarkupEntities = ( value ) => (
+    value.replace( /[&<>"]/g, character => markupEntities[character] )
+);
+
+const escapeMarkupURLPath = ( value ) => {
+    return escapeMarkupEntities(
+        transformer.escapeURLPath( value )
+    );
+};
+
 /**
  * Converts a url to a local (proxied) url.
  *
@@ -11,7 +41,7 @@ const transformer = require( 'enketo-transformer' );
 function toLocalMediaUrl( url ) {
     const localUrl = `${config[ 'base path' ]}/media/get/${url.replace( /(https?):\/\//, '$1/' )}`;
 
-    return transformer.escapeURLPath( localUrl );
+    return escapeMarkupURLPath( localUrl );
 }
 
 /**
@@ -27,11 +57,64 @@ function toLocalMediaUrl( url ) {
  */
 const toMediaMap = ( manifest ) => Object.fromEntries(
     manifest.map( ( { filename, downloadUrl } ) => (
-        [ filename, toLocalMediaUrl( downloadUrl ) ]
+        [ escapeMarkupURLPath( filename ), toLocalMediaUrl( downloadUrl ) ]
     ) )
 );
 
+/**
+ * @typedef {import('../models/survey-model').SurveyObject} Survey
+ */
+
+/**
+ * @param {Survey} survey
+ * @return {Survey}
+ */
+ const replaceMediaSources = ( survey ) => {
+    const media = toMediaMap( survey.manifest );
+
+    let { form, model } = survey;
+
+    if ( media ) {
+        const JR_URL = /"jr:\/\/[\w-]+\/([^"]+)"/g;
+        const replacer = ( match, filename ) => {
+            if ( media[ filename ] ) {
+
+                return `"${media[ filename ]}"`;
+            }
+
+            return match;
+        };
+
+        form = form.replace( JR_URL, replacer );
+        model = model.replace( JR_URL, replacer );
+
+        if ( media[ 'form_logo.png' ] ) {
+            survey.form = survey.form.replace(
+                /(class="form-logo"\s*>)/,
+                `$1<img src="${media['form_logo.png']}" alt="form logo">`
+            );
+        }
+    }
+
+    const manifest = survey.manifest.map( item => {
+        return {
+            ...item,
+            filename: escapeMarkupURLPath( item.filename ),
+            downloadUrl: escapeMarkupURLPath( item.downloadUrl )
+        };
+    } );
+
+
+    return {
+        ...survey,
+        form,
+        manifest,
+        model,
+    };
+};
+
 module.exports = {
+    replaceMediaSources,
     toLocalMediaUrl,
     toMediaMap,
 };

--- a/public/js/src/module/file-manager.js
+++ b/public/js/src/module/file-manager.js
@@ -61,7 +61,7 @@ function getFileUrl( subject ) {
                 resolve( instanceAttachments[ escapedSubject ] );
             } else if ( instanceAttachments && ( Object.prototype.hasOwnProperty.call( instanceAttachments, subject ) ) ) {
                 resolve( instanceAttachments[ subject ] );
-            } else if ( !store.available ) {
+            } else if ( !settings.offline || !store.available ) {
                 // e.g. in an online-only edit view
                 reject( new Error( 'store not available' ) );
             } else if ( URL_RE.test( subject ) ) {

--- a/test/server/transformation-controller.spec.js
+++ b/test/server/transformation-controller.spec.js
@@ -1,9 +1,11 @@
 const expect = require( 'chai' ).expect;
+const transformer = require( 'enketo-transformer' );
 const request = require( 'supertest' );
 const sinon = require( 'sinon' );
 const communicator = require( '../../app/lib/communicator' );
 const accountModel = require( '../../app/models/account-model' );
 const config = require( '../../app/models/config-model' ).server;
+const cacheModel = require( '../../app/models/cache-model' );
 const surveyModel = require( '../../app/models/survey-model' );
 const userModel = require( '../../app/models/user-model' );
 
@@ -14,11 +16,11 @@ const userModel = require( '../../app/models/user-model' );
 describe( 'Transformation Controller', () => {
     const basePath = '';
     const bearer = 'fozzie';
-    const credentials = { bearer };
     const enketoId = 'surveyZ';
-    const manifestHost = 'http://example.com';
+    const openRosaServer = 'http://example.com';
+    const openRosaId = 'formZ';
     const manifestPath = '/manifest';
-    const manifestUrl = `${manifestHost}${manifestPath}`;
+    const manifestUrl = `${openRosaServer}${manifestPath}`;
 
     /** @type {import('sinon').SinonSandbox} */
     let sandbox;
@@ -35,8 +37,8 @@ describe( 'Transformation Controller', () => {
     /** @type {Survey} */
     let survey;
 
-    /** @type {Survey} */
-    let surveyWithAccount;
+    /** @type {string} */
+    let hash;
 
     beforeEach( done => {
         sandbox = sinon.createSandbox();
@@ -45,32 +47,46 @@ describe( 'Transformation Controller', () => {
 
         // Stub `_getSurveyParams`
         survey = {
-            info: {
-                manifestUrl,
-            },
+            openRosaServer,
+            openRosaId,
         };
 
-        sandbox.stub( surveyModel, 'get' ).resolves( survey );
+        hash = 'md5:b4dd34d';
+
+        sandbox.stub( surveyModel, 'get' ).callsFake( () => (
+            Promise.resolve( { ...survey } )
+        ) );
 
         account = {};
 
-        surveyWithAccount = Object.assign( {}, survey, { account } );
-
-        sandbox.stub( accountModel, 'check' ).resolves( surveyWithAccount );
+        sandbox.stub( accountModel, 'check' ).callsFake( survey => (
+            Promise.resolve( {
+                ...survey,
+                account,
+            } )
+        ) );
 
         // No-op `_checkQuota`
         sandbox.stub( config, 'account lib' ).get( () => null );
 
-        sandbox.stub( userModel, 'getCredentials' ).resolves( credentials );
+        sandbox.stub( userModel, 'getCredentials' ).callsFake( async () => (
+            { bearer }
+        ) );
 
         app = require( '../../config/express' );
 
         server = app.listen( () => done() );
     } );
 
-    afterEach( done => {
+    afterEach( async () => {
         sandbox.restore();
-        server.close( done );
+
+        await Promise.all( [
+            cacheModel.flushAll(),
+            new Promise( ( resolve, reject ) => (
+                server.close( error => error ? reject( error ) : resolve() )
+            ) ),
+        ] );
     } );
 
     const requests = [
@@ -85,174 +101,363 @@ describe( 'Transformation Controller', () => {
         },
     ];
 
-    requests.forEach( ( { description, url, body } ) => {
-        describe( `jr: media URLs ${description}`, () => {
-            /** @type {import('enketo-transformer/src/transformer').TransformedSurvey} */
-            let result;
+    /**
+     * @typedef {import('../../app/lib/url').ManifestItem} ManifestItem
+     */
 
-            beforeEach( done => {
-                // Stub getXForm
-                const xform = `
-                    <?xml version="1.0"?>
-                    <h:html xmlns="http://www.w3.org/2002/xforms"
-                        xmlns:ev="http://www.w3.org/2001/xml-events"
-                        xmlns:h="http://www.w3.org/1999/xhtml"
-                        xmlns:jr="http://openrosa.org/javarosa"
-                        xmlns:odk="http://www.opendatakit.org/xforms"
-                        xmlns:orx="http://openrosa.org/xforms"
-                        xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-                        <h:head>
-                            <h:title>jr-url-space</h:title>
-                            <model>
-                                <itext>
-                                    <translation default="true()" lang="English">
-                                        <text id="/outside/l1:label">
-                                            <value form="image">jr://images/first image.jpg</value>
-                                        </text>
-                                        <text id="/outside/l2:label">
-                                            <value form="audio">jr://audio/a song.mp3</value>
-                                        </text>
-                                        <text id="/outside/l3:label">
-                                            <value form="video">jr://video/some video.mp4</value>
-                                        </text>
-                                    </translation>
-                                </itext>
-                                <instance>
-                                    <outside>
-                                        <a/>
-                                        <b/>
-                                        <c>jr://images/another image.png</c>
-                                        <d/>
-                                        <l1/>
-                                        <l2/>
-                                        <l2/>
-                                        <meta>
-                                            <instanceID/>
-                                        </meta>
-                                    </outside>
-                                </instance>
-                                <instance id="file" src="jr://file/an instance.xml" />
-                                <instance id="file-csv" src="jr://file-csv/a spreadsheet.csv" />
-                                <bind nodeset="/outside/a" type="string"/>
-                                <bind nodeset="/outside/b" type="string"/>
-                                <bind nodeset="/outside/c" type="binary"/>
-                                <bind nodeset="/outside/d" type="string"/>
-                            </model>
-                        </h:head>
-                        <h:body>
-                            <input ref="/a">
-                                <label ref="jr:itext('/outside/l1:label')"/>
-                            </input>
-                            <input ref="/b">
-                                <label ref="jr:itext('/outside/l2:label')"/>
-                            </input>
-                            <upload appearance="annotate" mediatype="image/*" ref="/outside/c">
-                                <label ref="jr:itext('/outside/l3:label')"/>
-                            </upload>
-                            <input> ref="/d">
-                                <label>
-                                    [markdown](jr://file/a link.xml)
-                                </label>
-                            </input>
-                        </h:body>
-                    </h:html>
-                `.trim();
+    /** @type {ManifestItem[]} */
+    let manifest;
 
-                const surveyWithXForm = Object.assign( {}, surveyWithAccount, { xform } );
+    /**
+     * @param {string} url
+     * @param {object} payload
+     * @return {import('enketo-transformer/src/transformer').TransformedSurvey}
+     */
+    const getTransormResult = async ( url, payload ) => {
+        const { body } = await request( app )
+            .post( url )
+            .send( payload )
+            .expect( 200 );
 
-                sandbox.stub( communicator, 'getXForm' ).resolves( surveyWithXForm );
+        return body;
+    };
 
-                // Stub getManifest
-                const manifest = [
-                    {
-                        filename: 'first image.jpg',
-                        hash: 'irrelevant',
-                        downloadUrl: 'hallo spaceboy/spiders from mars.jpg',
-                    },
-                    {
-                        filename: 'a song.mp3',
-                        hash: 'irrelevant',
-                        downloadUrl: 'hallo spaceboy/space oddity.mp3',
-                    },
-                    {
-                        filename: 'some video.mp4',
-                        hash: 'irrelevant',
-                        downloadUrl: 'hallo spaceboy/a small plot of land.mp4',
-                    },
-                    {
-                        filename: 'another image.png',
-                        hash: 'irrelevant',
-                        downloadUrl: 'hallo spaceboy/under pressure.png',
-                    },
-                    {
-                        filename: 'an instance.xml',
-                        hash: 'irrelevant',
-                        downloadUrl: 'hallo spaceboy/golden years.xml',
-                    },
-                    {
-                        filename: 'a spreadsheet.csv',
-                        hash: 'irrelevant',
-                        downloadUrl: 'hallo spaceboy/little wonder.csv',
-                    },
-                    {
-                        filename: 'a link.xml',
-                        hash: 'irrelevant',
-                        downloadUrl: 'hallo spaceboy/wishful beginnings.xml',
-                    },
-                ];
+    describe( 'jr: media URLs', () => {
+        beforeEach( async () => {
+            sandbox.stub( communicator, 'authenticate' ).callsFake( survey => (
+                Promise.resolve( survey )
+            ) );
 
-                const surveyWithManifest = Object.assign( {}, surveyWithXForm, { manifest } );
+            sandbox.stub( communicator, 'getXFormInfo' ).callsFake( survey => (
+                Promise.resolve( {
+                    ...survey,
+                    info: {
+                        hash,
+                        manifestUrl,
+                    },
+                } )
+            ) );
 
-                sandbox.stub( communicator, 'getManifest' ).resolves( surveyWithManifest );
+            // Stub getXForm
+            const xform = `
+                <?xml version="1.0"?>
+                <h:html xmlns="http://www.w3.org/2002/xforms"
+                    xmlns:ev="http://www.w3.org/2001/xml-events"
+                    xmlns:h="http://www.w3.org/1999/xhtml"
+                    xmlns:jr="http://openrosa.org/javarosa"
+                    xmlns:odk="http://www.opendatakit.org/xforms"
+                    xmlns:orx="http://openrosa.org/xforms"
+                    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                    <h:head>
+                        <h:title>jr-url-space</h:title>
+                        <model>
+                            <itext>
+                                <translation default="true()" lang="English">
+                                    <text id="/outside/l1:label">
+                                        <value form="image">jr://images/first image.jpg</value>
+                                    </text>
+                                    <text id="/outside/l2:label">
+                                        <value form="audio">jr://audio/a song.mp3</value>
+                                    </text>
+                                    <text id="/outside/l3:label">
+                                        <value form="video">jr://video/some video.mp4</value>
+                                    </text>
+                                </translation>
+                            </itext>
+                            <instance>
+                                <outside>
+                                    <a/>
+                                    <b/>
+                                    <c>jr://images/another image.png</c>
+                                    <d/>
+                                    <l1/>
+                                    <l2/>
+                                    <l2/>
+                                    <meta>
+                                        <instanceID/>
+                                    </meta>
+                                </outside>
+                            </instance>
+                            <instance id="file" src="jr://file/an instance.xml" />
+                            <instance id="file-csv" src="jr://file-csv/a spreadsheet.csv" />
+                            <bind nodeset="/outside/a" type="string"/>
+                            <bind nodeset="/outside/b" type="string"/>
+                            <bind nodeset="/outside/c" type="binary"/>
+                            <bind nodeset="/outside/d" type="string"/>
+                        </model>
+                    </h:head>
+                    <h:body>
+                        <input ref="/a">
+                            <label ref="jr:itext('/outside/l1:label')"/>
+                        </input>
+                        <input ref="/b">
+                            <label ref="jr:itext('/outside/l2:label')"/>
+                        </input>
+                        <upload appearance="annotate" mediatype="image/*" ref="/outside/c">
+                            <label ref="jr:itext('/outside/l3:label')"/>
+                        </upload>
+                        <input> ref="/d">
+                            <label>
+                                [markdown](jr://file/a link.xml)
+                            </label>
+                        </input>
+                    </h:body>
+                </h:html>
+            `.trim();
 
-                request( app )
-                    .post( url )
-                    .send( body )
-                    .expect( 200 )
-                    .then( ( { body } ) => {
-                        result = body;
-                    } )
-                    .then( done, done );
+            sandbox.stub( communicator, 'getXForm' ).callsFake( survey => (
+                Promise.resolve( {
+                    ...survey,
+                    xform,
+                } )
+            ) );
+
+            // Stub getManifest
+            manifest = [
+                {
+                    filename: 'first image.jpg',
+                    hash: 'irrelevant',
+                    downloadUrl: 'hallo spaceboy/spiders from mars.jpg',
+                },
+                {
+                    filename: 'a song.mp3',
+                    hash: 'irrelevant',
+                    downloadUrl: 'hallo spaceboy/space oddity.mp3',
+                },
+                {
+                    filename: 'some video.mp4',
+                    hash: 'irrelevant',
+                    downloadUrl: 'hallo spaceboy/a small plot of land.mp4',
+                },
+                {
+                    filename: 'another image.png',
+                    hash: 'irrelevant',
+                    downloadUrl: 'hallo spaceboy/under pressure.png',
+                },
+                {
+                    filename: 'an instance.xml',
+                    hash: 'irrelevant',
+                    downloadUrl: 'hallo spaceboy/golden years.xml',
+                },
+                {
+                    filename: 'a spreadsheet.csv',
+                    hash: 'irrelevant',
+                    downloadUrl: 'hallo spaceboy/little wonder.csv',
+                },
+                {
+                    filename: 'a link.xml',
+                    hash: 'irrelevant',
+                    downloadUrl: 'hallo spaceboy/wishful beginnings.xml',
+                },
+            ];
+
+            sandbox.stub( communicator, 'getManifest' ).callsFake( survey => (
+                Promise.resolve( {
+                    ...survey,
+                    manifest,
+                } )
+            ) );
+        } );
+
+        requests.forEach( ( { description, url, body } ) => {
+            describe( description, () => {
+                it( 'escapes media in labels', async () => {
+                    const result = await getTransormResult( url, body );
+
+                    return Promise.all( [
+                        expect( result ).to.have.property( 'form' ).and.to.not.contain( 'jr://images/first image.jpg' ),
+                        expect( result ).to.have.property( 'form' ).and.to.not.contain( 'jr://audio/a song.mp3' ),
+                        expect( result ).to.have.property( 'form' ).and.to.not.contain( 'jr://video/some video.mp4' ),
+
+                        expect( result ).to.have.property( 'form' ).and.to.contain( 'hallo%20spaceboy/spiders%20from%20mars.jpg' ),
+                        expect( result ).to.have.property( 'form' ).and.to.contain( 'hallo%20spaceboy/space%20oddity.mp3' ),
+                        expect( result ).to.have.property( 'form' ).and.to.contain( 'hallo%20spaceboy/a%20small%20plot%20of%20land.mp4' ),
+                    ] );
+                } );
+
+                it( 'escapes binary defaults', async () => {
+                    const result = await getTransormResult( url, body );
+
+                    return Promise.all( [
+                        expect( result ).to.have.property( 'model' ).and.to.not.contain( 'jr://images/another image.png' ),
+
+                        expect( result ).to.have.property( 'model' ).and.to.contain( 'hallo%20spaceboy/under%20pressure.png' ),
+                    ] );
+                } );
+
+                it( 'escapes external instance URLs', async () => {
+                    const result = await getTransormResult( url, body );
+
+                    return Promise.all( [
+                        expect( result ).to.have.property( 'model' ).and.to.not.contain( 'jr://file/an instance.xml' ),
+                        expect( result ).to.have.property( 'model' ).and.to.not.contain( 'jr://file-csv/a spreadsheet.csv' ),
+
+                        expect( result ).to.have.property( 'model' ).and.to.contain( 'hallo%20spaceboy/golden%20years.xml' ),
+                        expect( result ).to.have.property( 'model' ).and.to.contain( 'hallo%20spaceboy/little%20wonder.csv' ),
+                    ] );
+                } );
+
+
+                it( 'escapes media URLs in markdown linkes', async () => {
+                    const result = await getTransormResult( url, body );
+
+                    return Promise.all( [
+                        expect( result ).to.have.property( 'form' ).and.to.not.contain( 'jr://file/a link.xml' ),
+
+                        expect( result ).to.have.property( 'form' ).and.to.contain( 'hallo%20spaceboy/wishful%20beginnings.xml' ),
+                    ] );
+                } );
+
+                it( 'escapes html entities in mapped URLs', async () => {
+                    // Stub getManifest
+                    manifest = [
+                        {
+                            filename: 'first image.jpg',
+                            hash: 'irrelevant',
+                            downloadUrl: 'hallo spaceboy/<.jpg',
+                        },
+                        {
+                            filename: 'a song.mp3',
+                            hash: 'irrelevant',
+                            downloadUrl: 'hallo spaceboy/>.mp3',
+                        },
+                        {
+                            filename: 'some video.mp4',
+                            hash: 'irrelevant',
+                            downloadUrl: 'hallo spaceboy/&.mp4',
+                        },
+                        {
+                            filename: 'another image.png',
+                            hash: 'irrelevant',
+                            downloadUrl: 'hallo spaceboy/".png',
+                        },
+                    ];
+
+                    const result = await getTransormResult( url, body );
+
+                    expect( result.form ).not.to.contain( '<.jpg' );
+                    expect( result.form ).not.to.contain( '>.mp3' );
+                    expect( result.form ).not.to.contain( '&.mp4' );
+                    expect( result.model ).not.to.contain( '".png' );
+
+                    expect( result.form ).to.contain( 'hallo%20spaceboy/%3C.jpg' );
+                    expect( result.form ).to.contain( 'hallo%20spaceboy/%3E.mp3' );
+                    expect( result.form ).to.contain( 'hallo%20spaceboy/&amp;.mp4' );
+                    expect( result.model ).to.contain( 'hallo%20spaceboy/%22.png' );
+                } );
+
+                // This *shouldn't* happen but better safe than sorry
+                it( 'escapes html entities which were not escaped as entities', async () => {
+                    // Stub getManifest
+                    manifest = [
+                        {
+                            filename: 'first image.jpg',
+                            hash: 'irrelevant',
+                            downloadUrl: 'hallo spaceboy/<.jpg',
+                        },
+                        {
+                            filename: 'a song.mp3',
+                            hash: 'irrelevant',
+                            downloadUrl: 'hallo spaceboy/>.mp3',
+                        },
+                        {
+                            filename: 'some video.mp4',
+                            hash: 'irrelevant',
+                            downloadUrl: 'hallo spaceboy/&.mp4',
+                        },
+                        {
+                            filename: 'another image.png',
+                            hash: 'irrelevant',
+                            downloadUrl: 'hallo spaceboy/".png',
+                        },
+                    ];
+
+                    const escapeURLPath = transformer.escapeURLPath;
+
+                    sandbox.stub( transformer, 'escapeURLPath' ).callsFake( ( str ) => {
+                        const escaped = escapeURLPath( str );
+
+                        const unescapedEntities = {
+                            '%3C': '<',
+                            '%3E': '>',
+                            '%22': '"',
+                        };
+
+                        /**
+                         * @param {string} str
+                         */
+                        const unescapeEntities = ( str ) => (
+                            str.replace( /(%3C|%3E|%22)/g, escaped => unescapedEntities[ escaped ]
+                            )
+                        );
+
+                        return unescapeEntities( escaped );
+                    } );
+
+                    const result = await getTransormResult( url, body );
+
+                    expect( result.form ).not.to.contain( '<.jpg' );
+                    expect( result.form ).not.to.contain( '>.mp3' );
+                    expect( result.form ).not.to.contain( '&.mp4' );
+                    expect( result.model ).not.to.contain( '".png' );
+
+                    expect( result.form ).to.contain( 'hallo%20spaceboy/&lt;.jpg' );
+                    expect( result.form ).to.contain( 'hallo%20spaceboy/&gt;.mp3' );
+                    expect( result.form ).to.contain( 'hallo%20spaceboy/&amp;.mp4' );
+                    expect( result.model ).to.contain( 'hallo%20spaceboy/&quot;.png' );
+                } );
+            } );
+        } );
+
+        it( 'maps media with a new manifest without re-transforming the cached survey', async () => {
+            const initialCache = await cacheModel.get( {
+                openRosaServer,
+                openRosaId,
             } );
 
-            it( 'escapes media in labels', () => {
-                return Promise.all( [
-                    expect( result ).to.have.property( 'form' ).and.to.not.contain( 'jr://images/first image.jpg' ),
-                    expect( result ).to.have.property( 'form' ).and.to.not.contain( 'jr://audio/a song.mp3' ),
-                    expect( result ).to.have.property( 'form' ).and.to.not.contain( 'jr://video/some video.mp4' ),
+            expect( initialCache ).to.be.null;
 
-                    expect( result ).to.have.property( 'form' ).and.to.contain( 'hallo%20spaceboy/spiders%20from%20mars.jpg' ),
-                    expect( result ).to.have.property( 'form' ).and.to.contain( 'hallo%20spaceboy/space%20oddity.mp3' ),
-                    expect( result ).to.have.property( 'form' ).and.to.contain( 'hallo%20spaceboy/a%20small%20plot%20of%20land.mp4' ),
-                ] );
+            const { url, body } = requests[1];
+            const transformSpy = sandbox.spy( transformer, 'transform' );
+            const cacheSetSpy = sandbox.spy( cacheModel, 'set' );
+
+            const initialResult = await getTransormResult( url, body );
+
+            expect( initialResult.model ).to.contain( 'hallo%20spaceboy/under%20pressure.png' );
+
+            expect( transformSpy.calledOnce ).to.be.true;
+            expect( cacheSetSpy.calledOnce ).to.be.true;
+
+            const firstCache = await cacheModel.get( {
+                openRosaServer,
+                openRosaId,
             } );
 
-            it( 'escapes binary defaults', () => {
-                return Promise.all( [
-                    expect( result ).to.have.property( 'model' ).and.to.not.contain( 'jr://images/another image.png' ),
+            expect( firstCache.model ).to.contain( 'another%20image.png' );
 
-                    expect( result ).to.have.property( 'model' ).and.to.contain( 'hallo%20spaceboy/under%20pressure.png' ),
-                ] );
+            // Stub getManifest
+            manifest = [
+                {
+                    filename: 'another image.png',
+                    hash: 'irrelevant',
+                    downloadUrl: 'hallo spaceboy/the jean genie.png',
+                },
+            ];
+
+            const result = await getTransormResult( url, body );
+
+            expect( result.model ).not.to.contain( 'hallo%20spaceboy/under%20pressure.png' );
+            expect( result.model ).to.contain( 'hallo%20spaceboy/the%20jean%20genie.png' );
+
+            const finalCache = await cacheModel.get( {
+                openRosaServer,
+                openRosaId,
             } );
 
-            it( 'escapes external instance URLs', () => {
-                return Promise.all( [
-                    expect( result ).to.have.property( 'model' ).and.to.not.contain( 'jr://file/an instance.xml' ),
-                    expect( result ).to.have.property( 'model' ).and.to.not.contain( 'jr://file-csv/a spreadsheet.csv' ),
+            expect( finalCache ).to.deep.equal( firstCache );
 
-                    expect( result ).to.have.property( 'model' ).and.to.contain( 'hallo%20spaceboy/golden%20years.xml' ),
-                    expect( result ).to.have.property( 'model' ).and.to.contain( 'hallo%20spaceboy/little%20wonder.csv' ),
-                ] );
-            } );
-
-
-            it( 'escapes media URLs in markdown linkes', () => {
-                return Promise.all( [
-                    expect( result ).to.have.property( 'form' ).and.to.not.contain( 'jr://file/a link.xml' ),
-
-                    expect( result ).to.have.property( 'form' ).and.to.contain( 'hallo%20spaceboy/wishful%20beginnings.xml' ),
-                ] );
-            } );
+            expect( transformSpy.calledOnce ).to.be.true;
+            expect( cacheSetSpy.calledOnce ).to.be.true;
         } );
     } );
 } );

--- a/test/server/transformation-controller.spec.js
+++ b/test/server/transformation-controller.spec.js
@@ -298,7 +298,7 @@ describe( 'Transformation Controller', () => {
                 } );
 
 
-                it( 'escapes media URLs in markdown linkes', async () => {
+                it( 'escapes media URLs in markdown links', async () => {
                     const result = await getTransormResult( url, body );
 
                     return Promise.all( [

--- a/test/server/url.spec.js
+++ b/test/server/url.spec.js
@@ -66,9 +66,9 @@ describe( 'URL functionality', () => {
             } ) );
 
             expect( toMediaMap( manifest ) ).to.deep.equal( {
-                'an image.jpg':     'http://enke.to/media/get/https/example.com/an%20image.jpg',
-                'beastie boys.mp4': 'http://enke.to/media/get/https/example.com/beastie%20boys.mp4',
-                'cd rip.mp3':       'http://enke.to/media/get/https/example.com/cd%20rip.mp3',
+                'an%20image.jpg':     'http://enke.to/media/get/https/example.com/an%20image.jpg',
+                'beastie%20boys.mp4': 'http://enke.to/media/get/https/example.com/beastie%20boys.mp4',
+                'cd%20rip.mp3':       'http://enke.to/media/get/https/example.com/cd%20rip.mp3',
             } );
         } );
     } );


### PR DESCRIPTION
Closes #356

#### I have verified this PR works with 

- [x] Online form submission
- [x] Offline form submission
- [x] Saving offline drafts
- [x] Submitting offline drafts
- [x] Editing submissions
- [x] Form preview
- ~~[ ] None of the above~~

#### What else has been done to verify that this works as intended?

- Loaded a form with binary defaults in a public access link (logged out, in Incognito mode) to verify that the media loads with the form's dynamic public access token.
- Validated that transformer escapes the same special HTML/XML characters with the same entities
- Validated that spaces and other special URL characters continue to be escaped and mapped as expected

#### Why is this the best possible solution? Were any other approaches considered?

This is a slightly safer (escaping reserved HTML/XML entities, still handles spaces and other URL characters that need to be escaped) version of the previous solution, before #291 and was determined to be the lowest risk short-term solution. Other solutions considered:

- Dynamically map media in the frontend DOM on load. This turned out to be unexpectedly complex.
- Transform for each distinct manifest. This would likely be a performance regression.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

- It's possible, though probably unlikely, that the string replacement approach will find false positives.

#### Do we need any specific form for testing your changes? If so, please attach one.

Any form with binary defaults (currently only for annotation fields, see #359).