### PR TITLE
Fix: ensure form_logo.png is included when present in media mapping

### DIFF
--- a/app/lib/url.js
+++ b/app/lib/url.js
@@ -89,7 +89,7 @@ const replaceMediaSources = ( survey ) => {
         model = model.replace( JR_URL, replacer );
 
         if ( media[ 'form_logo.png' ] ) {
-            survey.form = survey.form.replace(
+            form = form.replace(
                 /(class="form-logo"\s*>)/,
                 `$1<img src="${media['form_logo.png']}" alt="form logo">`
             );

--- a/test/server/transformation-controller.spec.js
+++ b/test/server/transformation-controller.spec.js
@@ -406,6 +406,38 @@ describe( 'Transformation Controller', () => {
                     expect( result.form ).to.contain( 'hallo%20spaceboy/&amp;.mp4' );
                     expect( result.model ).to.contain( 'hallo%20spaceboy/&quot;.png' );
                 } );
+
+                it( 'includes form_logo.png when present in the media mapping', async () => {
+                    manifest = [
+                        {
+                            filename: 'form_logo.png',
+                            hash: 'irrelevant',
+                            downloadUrl: 'form_logo.png',
+                        },
+                    ];
+
+                    const result = await getTransormResult( url, body );
+
+                    expect( result.form ).to.contain(
+                        `<section class="form-logo"><img src="${basePath}/media/get/form_logo.png" alt="form logo"></section>`
+                    );
+                } );
+
+                it( 'escapes the form_logo.png downloadUrl base bath', async () => {
+                    manifest = [
+                        {
+                            filename: 'form_logo.png',
+                            hash: 'irrelevant',
+                            downloadUrl: 'hallo spaceboy/form_logo.png',
+                        },
+                    ];
+
+                    const result = await getTransormResult( url, body );
+
+                    expect( result.form ).to.contain(
+                        `<section class="form-logo"><img src="${basePath}/media/get/hallo%20spaceboy/form_logo.png" alt="form logo"></section>`
+                    );
+                } );
             } );
         } );
 


### PR DESCRIPTION
Closes enketo/enketo-core#850.

#### I have verified this PR works with 
- [x] Online form submission
- [x] Offline form submission
- [x] Saving offline drafts
- [x] Submitting offline drafts
- [x] Editing submissions
- [x] Form preview
- [ ] None of the above

#### What else has been done to verify that this works as intended?

Tests for both presence of form_logo.png and escaping its base path.

#### Why is this the best possible solution? Were any other approaches considered?

This was a regression in #360, which incorrectly restored the original escaping logic that was removed in #291. That logic previously mutated the `survey` parameter, when restoring it I intended to return a new `survey` object but missed this particular one.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I can not foresee any risk from this change that wasn't already a risk in #360 or #291.

#### Do we need any specific form for testing your changes? If so, please attach one.

See the attachment on enketo/enketo-core#850.