### PR TITLE
Update offline script version at build time

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -72,6 +72,15 @@
                 "browser": false,
                 "node": true
             }
+        },
+        {
+            "files": [
+                "public/js/src/module/offline-app-worker.js"
+            ],
+            "globals": {
+                "OFFLINE_APP_WORKER_RESOURCES": true,
+                "OFFLINE_APP_WORKER_VERSION": true
+            }
         }
     ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -78,8 +78,7 @@
                 "public/js/src/module/offline-app-worker.js"
             ],
             "globals": {
-                "OFFLINE_APP_WORKER_RESOURCES": true,
-                "OFFLINE_APP_WORKER_VERSION": true
+                "OFFLINE_APP_WORKER_CONFIG": true
             }
         }
     ]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,10 +1,9 @@
 module.exports = grunt => {
     const JS_INCLUDE = [
         '**/*.js',
-        '!**/offline-app-worker-partial.js',
         '!**/node_modules/**',
         '!test/**/*.spec.js',
-        '!public/js/build/*',
+        '!public/js/build/**/*',
         '!test/client/config/karma.conf.js',
         '!docs/**',
         '!test-coverage/**',
@@ -100,7 +99,7 @@ module.exports = grunt => {
                 command: 'find locales -name "translation-combined.json" -delete && rm -fr locales/??'
             },
             'clean-js': {
-                command: 'rm -f public/js/build/* && rm -f public/js/*.js'
+                command: 'rm -f public/js/build/**/* && rm -f public/js/*.js'
             },
             translation: {
                 command: 'echo "No automatic translation key generation at the moment."'

--- a/app/controllers/offline-controller.js
+++ b/app/controllers/offline-controller.js
@@ -4,7 +4,6 @@
 
 const fs = require( 'fs' );
 const path = require( 'path' );
-const crypto = require( 'crypto' );
 const express = require( 'express' );
 const router = express.Router();
 const config = require( '../models/config-model' ).server;
@@ -14,6 +13,7 @@ const config = require( '../models/config-model' ).server;
 module.exports = app => {
     app.use( `${app.get( 'base path' )}/`, router );
 };
+
 router
     .get( '/x/offline-app-worker.js', ( req, res, next ) => {
         if ( config[ 'offline enabled' ] === false ) {
@@ -21,42 +21,10 @@ router
             error.status = 404;
             next( error );
         } else {
+            const scriptContent = fs.readFileSync( path.resolve( config.root, 'public/js/build/module/offline-app-worker.js' ), 'utf8' );
+
             res
                 .set( 'Content-Type', 'text/javascript' )
-                .send( getScriptContent() );
+                .send( scriptContent );
         }
     } );
-
-/**
- * Assembles script contentå
- */
-function getScriptContent() {
-    // Determining hash every time, is done to make development less painful (refreshing service worker)
-    // The partialScriptHash is not actually required but useful to see which offline-app-worker-partial.js is used during troubleshooting.
-    // by going to http://localhost:8005/x/offline-app-worker.js and comparing the version with the version shown in the side slider of the webform.
-    const partialOfflineAppWorkerScript = fs.readFileSync( path.resolve( config.root, 'public/js/src/module/offline-app-worker-partial.js' ), 'utf8' );
-    const partialScriptHash = crypto.createHash( 'md5' ).update( partialOfflineAppWorkerScript ).digest( 'hex' ).substring( 0, 7 );
-    const configurationHash = crypto.createHash( 'md5' ).update( JSON.stringify( config ) ).digest( 'hex' ).substring( 0, 7 );
-    const version = [ config.version, configurationHash, partialScriptHash ].join( '-' );
-    // We add as few explicit resources as possible because the offline-app-worker can do this dynamically and that is preferred
-    // for easier maintenance of the offline launch feature.
-    const resources = config[ 'themes supported' ]
-        .reduce( ( accumulator, theme ) => {
-            accumulator.push( `${config['base path']}${config['offline path']}/css/theme-${theme}.css` );
-            accumulator.push( `${config['base path']}${config['offline path']}/css/theme-${theme}.print.css` );
-
-            return accumulator;
-        }, [] )
-        .concat( [
-            `${config['base path']}${config['offline path']}/images/icon_180x180.png`
-        ] );
-
-    return `
-const version = '${version}';
-const resources = [
-    '${resources.join( '\',\n    \'' )}'
-];
-
-${partialOfflineAppWorkerScript}`;
-
-}

--- a/config/build.js
+++ b/config/build.js
@@ -11,24 +11,16 @@ const entryPoints = pkg.entries.map( entry => (
 
 const isProduction = process.env.NODE_ENV === 'production';
 
-const offlineResources = config['themes supported']
-    .reduce( ( accumulator, theme ) => {
-        accumulator.push( `${config['base path']}${config['offline path']}/css/theme-${theme}.css` );
-        accumulator.push( `${config['base path']}${config['offline path']}/css/theme-${theme}.print.css` );
-
-        return accumulator;
-    }, [] )
-    .concat( [
-        `${config['base path']}${config['offline path']}/images/icon_180x180.png`
-    ] );
-
-const offlineVersion = `${pkg.version}-${Date.now()}`;
+const offlineConfig = {
+    basePath: `${config['base path']}${config['offline path']}`,
+    themesSupported: config['themes supported'],
+    version: `${pkg.version}-${Date.now()}`,
+};
 
 module.exports = {
     bundle: true,
     define: {
-        OFFLINE_APP_WORKER_RESOURCES: JSON.stringify( offlineResources ),
-        OFFLINE_APP_WORKER_VERSION: JSON.stringify( offlineVersion ),
+        OFFLINE_APP_WORKER_CONFIG: JSON.stringify( offlineConfig ),
     },
     entryPoints: [
         ...entryPoints,

--- a/config/build.js
+++ b/config/build.js
@@ -1,6 +1,7 @@
 const alias = require( 'esbuild-plugin-alias' );
 const path = require( 'path' );
 const pkg = require( '../package.json' );
+const config = require( '../app/models/config-model' ).server;
 
 const cwd = process.cwd();
 
@@ -10,9 +11,29 @@ const entryPoints = pkg.entries.map( entry => (
 
 const isProduction = process.env.NODE_ENV === 'production';
 
+const offlineResources = config['themes supported']
+    .reduce( ( accumulator, theme ) => {
+        accumulator.push( `${config['base path']}${config['offline path']}/css/theme-${theme}.css` );
+        accumulator.push( `${config['base path']}${config['offline path']}/css/theme-${theme}.print.css` );
+
+        return accumulator;
+    }, [] )
+    .concat( [
+        `${config['base path']}${config['offline path']}/images/icon_180x180.png`
+    ] );
+
+const offlineVersion = `${pkg.version}-${Date.now()}`;
+
 module.exports = {
     bundle: true,
-    entryPoints,
+    define: {
+        OFFLINE_APP_WORKER_RESOURCES: JSON.stringify( offlineResources ),
+        OFFLINE_APP_WORKER_VERSION: JSON.stringify( offlineVersion ),
+    },
+    entryPoints: [
+        ...entryPoints,
+        path.resolve( cwd, 'public/js/src/module/offline-app-worker.js' ),
+    ],
     format: 'iife',
     minify: isProduction,
     outdir: path.resolve( cwd, './public/js/build' ),

--- a/public/js/src/module/offline-app-worker.js
+++ b/public/js/src/module/offline-app-worker.js
@@ -2,8 +2,22 @@
  * The `OFFLINE_APP_WORKER_*` variables are dynamically injected at build time.
  */
 
-const resources = OFFLINE_APP_WORKER_RESOURCES;
-const version = OFFLINE_APP_WORKER_VERSION;
+const {
+    basePath,
+    version,
+    themesSupported,
+} = OFFLINE_APP_WORKER_CONFIG;
+
+const resources = themesSupported
+    .reduce( ( accumulator, theme ) => {
+        accumulator.push( `${basePath}/css/theme-${theme}.css` );
+        accumulator.push( `${basePath}/css/theme-${theme}.print.css` );
+
+        return accumulator;
+    }, [] )
+    .concat( [
+        `${basePath}/images/icon_180x180.png`
+    ] );
 
 const CACHES = [ `enketo-common_${version}` ];
 

--- a/public/js/src/module/offline-app-worker.js
+++ b/public/js/src/module/offline-app-worker.js
@@ -1,6 +1,9 @@
 /**
- * The version, resources variables above are dynamically prepended by the offline-controller.
+ * The `OFFLINE_APP_WORKER_*` variables are dynamically injected at build time.
  */
+
+const resources = OFFLINE_APP_WORKER_RESOURCES;
+const version = OFFLINE_APP_WORKER_VERSION;
 
 const CACHES = [ `enketo-common_${version}` ];
 


### PR DESCRIPTION
This change:

1. ensures that offline-app-worker.js is updated automatically in offline mode, for every build (including dev watch mode), using `Date.now()` instead of calculating a hash of specific files
2. injects `version` and `resources` using esbuild's `define` config, rather than concatenating the module as a string

I've wanted to address this for some time, as it's been a frequent cause of false negatives and positives in dev/review/QA, as it was again in #373.

#### I have verified this PR works with 
- [ ] Online form submission
- [x] Offline form submission
- [x] Saving offline drafts
- [x] Submitting offline drafts
- [ ] Editing submissions
- [ ] Form preview
- [ ] None of the above

#### What else has been done to verify that this works as intended?

Manually verifying that a new version is loaded and available when saving a client module.

#### Why is this the best possible solution? Were any other approaches considered?

I believe this is consistent with what users, contributors and reviewers/QA would expect. It also makes testing offline-app-worker.js possible in the future, as we continue to expand test coverage.

I also considered expanding the hashing logic, but that felt unnecessarily complex to me.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This could potentially send updates for changes which only affect online mode or server-side functionality, but I think the effect of that is minimal enough that it's worth it.

#### Do we need any specific form for testing your changes? If so, please attach one.

N/A