### PR TITLE
Fix: use commit hash as version fallback when git tag is not available

### DIFF
--- a/.github/workflows/ghrc.yml
+++ b/.github/workflows/ghrc.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Store version information
+        run: git describe --tags || git rev-parse --short HEAD > .tag.txt
+
       # Login against a Docker registry
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}


### PR DESCRIPTION
Closes #

#### I have verified this PR works with 
- [x] GitHub Action
~~- [ ] Online form submission~~
~~- [ ] Offline form submission~~
~~- [ ] Saving offline drafts~~
~~- [ ] Submitting offline drafts~~
~~- [ ] Editing submissions~~
~~- [ ] Form preview~~
~~- [ ] None of the above~~

#### What else has been done to verify that this works as intended?

I originally committed with a `cat .tag.txt` to validate that it does populate the file as expected.

#### Why is this the best possible solution? Were any other approaches considered?

It's probably not, but if we _do_ have git context within the Docker image we should probably remove that.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It will display the deployed commit hash when building an untagged version.

#### Do we need any specific form for testing your changes? If so, please attach one.

N/A