### PR TITLE
Test if authType is set to cookie

### DIFF
--- a/app/models/user-model.js
+++ b/app/models/user-model.js
@@ -19,7 +19,7 @@ function getCredentials( req ) {
     const authType = auth.type.toLowerCase();
     let creds = null;
 
-    if ( authType === 'basic' ) {
+    if ( authType === 'basic' || authType === 'cookie' ) {
         const jwToken = req.signedCookies[ req.app.get( 'authentication cookie name' ) ];
         creds = ( jwToken ) ? jwt.decode( jwToken, req.app.get( 'encryption key' ) ) : null;
     } else if ( authType === 'token' ) {


### PR DESCRIPTION
Except configuration error on my part, when we config the auth as : 
```
"authentication" : {
        "type": "cookie",
        "url": "http://example.com/login?return={RETURNURL}"
}
```
we need to test if `authType === 'cookie'` juste like `basic` auth type in user-model.js ?

#### I have verified this PR works with 
- [x] Online form submission
- [ ] Offline form submission
- [ ] Saving offline drafts
- [ ] Submitting offline drafts
- [ ] Editing submissions
- [ ] Form preview
- [ ] None of the above
