### PR TITLE
Add configurable security headers

### DIFF
--- a/config/default-config.json
+++ b/config/default-config.json
@@ -114,5 +114,10 @@
         "seconds": 0,
         "preload": false,
         "include subdomains": false
+    },
+    "csp": {
+        "enabled": false,
+        "report only": false,
+        "value": null
     }
 }

--- a/config/default-config.json
+++ b/config/default-config.json
@@ -110,6 +110,8 @@
     "validate page": true,
     "payload limit": "100kb",
     "text field character limit": 2000,
+    "frameguard deny": false,
+    "no sniff": false,
     "hsts": {
         "seconds": 0,
         "preload": false,

--- a/config/default-config.json
+++ b/config/default-config.json
@@ -109,5 +109,10 @@
     "validate continuously": false,
     "validate page": true,
     "payload limit": "100kb",
-    "text field character limit": 2000
+    "text field character limit": 2000,
+    "hsts": {
+        "seconds": 0,
+        "preload": false,
+        "include subdomains": false
+    }
 }

--- a/config/express.js
+++ b/config/express.js
@@ -130,7 +130,7 @@ app.use((req, res, next) => {
     res.append('X-Frame-Options', 'DENY');
     res.append('X-Content-Type-Options', 'nosniff');
     const hsts = req.app.get('hsts');
-    if (hsts) {
+    if (hsts && hsts.seconds !== 0) {
         const directives = [hsts.seconds];
         if (hsts.preload) {
             directives.push('preload');
@@ -142,7 +142,7 @@ app.use((req, res, next) => {
     }
     const defaultCSP = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
     const csp = req.app.get('csp')
-    if (csp) {
+    if (csp && csp.enabled) {
         const cspHeader = csp['report only'] ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy';
         res.append(cspHeader, csp.value || defaultCSP);
     }

--- a/config/express.js
+++ b/config/express.js
@@ -136,7 +136,7 @@ if (app.get('no sniff') === true) {
 const hsts = app.get('hsts');
 const hstsDirectives = [];
 if (hsts && hsts.seconds !== 0) {
-    hstsDirectives.push('max-age=' + hsts.seconds);
+    hstsDirectives.push(`max-age=${hsts.seconds}`);
     if (hsts.preload) {
         hstsDirectives.push('preload');
     }
@@ -145,10 +145,13 @@ if (hsts && hsts.seconds !== 0) {
     }
     securityHeaders['Strict-Transport-Security'] = hstsDirectives.join('; ');
 }
-const defaultCSP = "default-src 'self'; script-src 'self' 'unsafe-inline' data:; style-src 'self' 'unsafe-inline' data:; img-src 'self' data:"
-const csp = app.get('csp')
+const defaultCSP =
+    "default-src 'self'; script-src 'self' 'unsafe-inline' data:; style-src 'self' 'unsafe-inline' data:; img-src 'self' data:";
+const csp = app.get('csp');
 if (csp && csp.enabled) {
-    const cspHeader = csp['report only'] ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy';
+    const cspHeader = csp['report only']
+        ? 'Content-Security-Policy-Report-Only'
+        : 'Content-Security-Policy';
     securityHeaders[cspHeader] = csp.value || defaultCSP;
 }
 // If any security headers are set, apply middleware
@@ -160,7 +163,6 @@ if (Object.keys(securityHeaders).length > 0) {
         next();
     });
 }
-
 
 // load controllers (including their routers)
 fs.readdirSync(controllersPath).forEach((file) => {

--- a/config/express.js
+++ b/config/express.js
@@ -125,6 +125,23 @@ app.use((req, res, next) => {
     next();
 });
 
+// set security headers
+app.use((req, res, next) => {
+    const hsts = req.app.get('hsts');
+    if (hsts) {
+        const directives = [hsts.seconds];
+        if (hsts.preload) {
+            directives.push("preload");
+        }
+        if (hsts["include subdomains"]) {
+            directives.push("includeSubDomains");
+        }
+        res.append('Strict-Transport-Security', directives.join('; '));
+    }
+    next();
+});
+
+
 // load controllers (including their routers)
 fs.readdirSync(controllersPath).forEach((file) => {
     if (file.indexOf('-controller.js') >= 0) {

--- a/config/express.js
+++ b/config/express.js
@@ -127,16 +127,24 @@ app.use((req, res, next) => {
 
 // set security headers
 app.use((req, res, next) => {
+    res.append('X-Frame-Options', 'DENY');
+    res.append('X-Content-Type-Options', 'nosniff');
     const hsts = req.app.get('hsts');
     if (hsts) {
         const directives = [hsts.seconds];
         if (hsts.preload) {
-            directives.push("preload");
+            directives.push('preload');
         }
-        if (hsts["include subdomains"]) {
-            directives.push("includeSubDomains");
+        if (hsts['include subdomains']) {
+            directives.push('includeSubDomains');
         }
         res.append('Strict-Transport-Security', directives.join('; '));
+    }
+    const defaultCSP = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
+    const csp = req.app.get('csp')
+    if (csp) {
+        const cspHeader = csp['report only'] ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy';
+        res.append(cspHeader, csp.value || defaultCSP);
     }
     next();
 });

--- a/config/express.js
+++ b/config/express.js
@@ -126,28 +126,40 @@ app.use((req, res, next) => {
 });
 
 // set security headers
-app.use((req, res, next) => {
-    res.append('X-Frame-Options', 'DENY');
-    res.append('X-Content-Type-Options', 'nosniff');
-    const hsts = req.app.get('hsts');
-    if (hsts && hsts.seconds !== 0) {
-        const directives = [hsts.seconds];
-        if (hsts.preload) {
-            directives.push('preload');
-        }
-        if (hsts['include subdomains']) {
-            directives.push('includeSubDomains');
-        }
-        res.append('Strict-Transport-Security', directives.join('; '));
+const securityHeaders = {};
+if (app.get('frameguard deny') === true) {
+    securityHeaders['X-Frame-Options'] = 'DENY';
+}
+if (app.get('no sniff') === true) {
+    securityHeaders['X-Content-Type-Options'] = 'nosniff';
+}
+const hsts = app.get('hsts');
+const hstsDirectives = [];
+if (hsts && hsts.seconds !== 0) {
+    hstsDirectives.push('max-age=' + hsts.seconds);
+    if (hsts.preload) {
+        hstsDirectives.push('preload');
     }
-    const defaultCSP = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
-    const csp = req.app.get('csp')
-    if (csp && csp.enabled) {
-        const cspHeader = csp['report only'] ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy';
-        res.append(cspHeader, csp.value || defaultCSP);
+    if (hsts['include subdomains']) {
+        hstsDirectives.push('includeSubDomains');
     }
-    next();
-});
+    securityHeaders['Strict-Transport-Security'] = hstsDirectives.join('; ');
+}
+const defaultCSP = "default-src 'self'; script-src 'self' 'unsafe-inline' data:; style-src 'self' 'unsafe-inline' data:; img-src 'self' data:"
+const csp = app.get('csp')
+if (csp && csp.enabled) {
+    const cspHeader = csp['report only'] ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy';
+    securityHeaders[cspHeader] = csp.value || defaultCSP;
+}
+// If any security headers are set, apply middleware
+if (Object.keys(securityHeaders).length > 0) {
+    app.use((req, res, next) => {
+        for (const [header, value] of Object.entries(securityHeaders)) {
+            res.append(header, value);
+        }
+        next();
+    });
+}
 
 
 // load controllers (including their routers)

--- a/tutorials/10-configure.md
+++ b/tutorials/10-configure.md
@@ -219,3 +219,19 @@ Sets which IPs should be filtered out to prevent SSRF attacks. See more here: ht
 -   `allowMetaIPAddress`: Default is `false`. Prevents or allows meta IP addresses to make GET and HEAD requests.
 -   `allowIPAddressList`: Default is `[]`. The list of allowed IP addresses. These are preferred over `denyAddressList`.
 -   `denyAddressList`: Default is `[]`. The list of denied IP addresses.
+
+#### hsts
+
+Set HTTP Strict Transport Security (HSTS) headers in express. Default is disabled. See more here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+
+-   `seconds`: Default is `0`. Seconds for HSTS to be enabled. When set to 0, header will not be set and HSTS is disabled. Set to a low number to test. For production, set to 63072000 (2 years).
+-   `preload`: Default is `false`. Submit to HSTS preload service.
+-   `includeSubDomains`: Default is `false`. When set, all subdomains will be subject to same HSTS rules.
+
+#### csp
+
+Set Content Security Policy (CSP) headers in express. Default is disabled. When enabled, a default policy is applied unless the `value` field is provided. See more here: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+
+-   `enabled`: Default is `false`. Set to `true` to enable CSP headers.
+-   `report only`: Default is `false`. Set to `true` to report, but not enforce, CSP.
+-   `value`: Default is `null`. Set to a custom value to override default CSP value.

--- a/tutorials/10-configure.md
+++ b/tutorials/10-configure.md
@@ -220,7 +220,6 @@ Sets which IPs should be filtered out to prevent SSRF attacks. See more here: ht
 -   `allowIPAddressList`: Default is `[]`. The list of allowed IP addresses. These are preferred over `denyAddressList`.
 -   `denyAddressList`: Default is `[]`. The list of denied IP addresses.
 
-
 ### frameguard deny
 
 Set to `true` to set the X-Frame-Options header to DENY to help you mitigate clickjacking attacks. Default is `false`. See more here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options

--- a/tutorials/10-configure.md
+++ b/tutorials/10-configure.md
@@ -220,6 +220,15 @@ Sets which IPs should be filtered out to prevent SSRF attacks. See more here: ht
 -   `allowIPAddressList`: Default is `[]`. The list of allowed IP addresses. These are preferred over `denyAddressList`.
 -   `denyAddressList`: Default is `[]`. The list of denied IP addresses.
 
+
+### frameguard deny
+
+Set to `true` to set the X-Frame-Options header to DENY to help you mitigate clickjacking attacks. Default is `false`. See more here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+
+### no sniff
+
+Set to `true` to set the X-Content-Type-Options header to nosniff. This mitigates MIME type sniffing which can cause security vulnerabilities. Default is `false`. See more here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+
 #### hsts
 
 Set HTTP Strict Transport Security (HSTS) headers in express. Default is disabled. See more here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security


### PR DESCRIPTION
Closes #399

Adds optional configuration values

```
    "hsts": {
        "include subdomains": false,
        "preload": false,
        "seconds": 100000
    },
    "csp": {
        "enabled": true
        "report only": true,
        "value": "some optional custom header value"
    },
```
These values are safe to omit.

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [x] Saving offline drafts
-   [x] Submitting offline drafts
-   [x] Editing submissions
-   [x] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?

The default behavior, based on config, is to add only already documented security headers. Presumably those are safe as they are already recommended. 

#### Why is this the best possible solution? Were any other approaches considered?

IMO a tool such as [helmet](https://github.com/helmetjs/helmet) is more robust and less code for us to maintain, however it was recommended to avoid adding packages. Which sounds reasonable to me.

One could argue that security headers should be set in nginx (or other proxy/load balancer/etc) instead. However this creates extra burden for some users and can be a unnecessary requirement when express can add headers. Consider an EKS cluster that uses AWS ALB. We already have a load balancer, ingress, perhaps a CDN. Throwing in nginx feels unnecessary in this case. Setting headers in express also let's use bake in good defaults and easier to configure options.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

If a user does not update their configuration, it should only add the already recommended headers

- X-Frame-Options DENY; 
- X-Content-Type-Options nosniff;