### PR TITLE
clean

### DIFF
--- a/public/js/src/module/feedback-bar.js
+++ b/public/js/src/module/feedback-bar.js
@@ -15,8 +15,8 @@ export default {
         return this.feedbackBar.querySelectorAll('p');
     },
     setCloseHandler() {
-        document
-            .querySelector('#feedback-bar .close, .touch #feedback-bar')
+        this.feedbackBar
+            .querySelector('.close')
             .addEventListener('click', () => {
                 this.hide();
             });

--- a/public/js/src/module/feedback-bar.js
+++ b/public/js/src/module/feedback-bar.js
@@ -1,0 +1,62 @@
+export default {
+    /**
+     * @return {Element}
+     */
+    get feedbackBar() {
+        if (!this._fbBar) {
+            this._fbBar = document.querySelector('#feedback-bar');
+        }
+        return this._fbBar;
+    },
+    /**
+     * @return {NodeList}
+     */
+    get messages() {
+        return this.feedbackBar.querySelectorAll('p');
+    },
+    setCloseHandler() {
+        document
+            .querySelector('#feedback-bar .close, .touch #feedback-bar')
+            .addEventListener('click', () => {
+                this.hide();
+            });
+    },
+    /**
+     * Shows an unobtrusive feedback bar to the user.
+     *
+     * @param { string } message - message to show
+     * @param {number=} duration - duration in seconds for the message to show
+     */
+    show(message, duration) {
+        // Max 2 messages displayed
+        this.feedbackBar.classList.add('feedback-bar--show');
+        const { messages } = this;
+        if (messages.length > 1) {
+            messages[1].remove();
+        }
+
+        // If an already shown message isn't exactly the same
+        if (!messages[0] || messages[0].innerHTML !== message.trim()) {
+            const newMessage = document.createElement('p');
+            newMessage.innerHTML = message.trim();
+            this.feedbackBar.prepend(newMessage);
+
+            // Automatically remove newly added feedback after a period
+            if (duration) {
+                setTimeout(() => {
+                    newMessage.remove();
+                    if (this.messages.length === 0) {
+                        this.hide();
+                    }
+                }, duration * 1000);
+            }
+        }
+    },
+    /**
+     * Hides and empties the feedback bar
+     */
+    hide() {
+        this.feedbackBar.classList.remove('feedback-bar--show');
+        this.messages.forEach((p) => p.remove());
+    },
+};

--- a/public/js/src/module/gui.js
+++ b/public/js/src/module/gui.js
@@ -7,6 +7,7 @@ import support from 'enketo-core/src/js/support';
 import * as printHelper from 'enketo-core/src/js/print';
 import vex from 'vex-js';
 import $ from 'jquery';
+import feedbackBar from './feedback-bar';
 import settings from './settings';
 import { init as initTranslator, t } from './translator';
 import sniffer from './sniffer';
@@ -18,7 +19,6 @@ let pages;
 let homeScreenGuidance;
 let updateStatus;
 let formTheme;
-let feedbackBar;
 
 // Customize vex
 vex.registerPlugin(vexEnketoDialog);
@@ -179,60 +179,6 @@ function swapTheme(formParts) {
         }
     });
 }
-
-feedbackBar = {
-    get feedbackBar() {
-        if (!this._fbBar) {
-            this._fbBar = document.querySelector('#feedback-bar');
-        }
-        return this._fbBar;
-    },
-    get messages() {
-        return this.feedbackBar.querySelectorAll('p');
-    },
-    setCloseHandler() {
-        document
-            .querySelector('#feedback-bar .close, .touch #feedback-bar')
-            .addEventListener('click', () => {
-                this.hide();
-            });
-    },
-    /**
-     * Shows an unobtrusive feedback bar to the user.
-     *
-     * @param { string } message - message to show
-     * @param {number=} duration - duration in seconds for the message to show
-     */
-    show(message, duration) {
-        // Max 2 messages displayed
-        this.feedbackBar.classList.add('feedback-bar--show');
-        const { messages } = this;
-        if (messages.length > 1) {
-            messages[1].remove();
-        }
-
-        // If an already shown message isn't exactly the same
-        if (!messages[0] || messages[0].innerHTML !== message.trim()) {
-            const newMessage = document.createElement('p');
-            newMessage.innerHTML = message.trim();
-            this.feedbackBar.prepend(newMessage);
-
-            // Automatically remove newly added feedback after a period
-            if (duration) {
-                setTimeout(() => {
-                    newMessage.remove();
-                    if (this.messages.length === 0) {
-                        this.hide();
-                    }
-                }, duration * 1000);
-            }
-        }
-    },
-    hide() {
-        this.feedbackBar.classList.remove('feedback-bar--show');
-        this.messages.forEach((p) => p.remove());
-    },
-};
 
 /**
  * Select what type of unobtrusive feedback message to show to the user.

--- a/public/js/src/module/gui.js
+++ b/public/js/src/module/gui.js
@@ -185,7 +185,7 @@ function swapTheme(formParts) {
  *
  * @param { string }  message - message to show
  * @param {number=} duration - duration in seconds for the message to show
- * @param {string=} duration - heading to show (on mobile only)
+ * @param {string=} heading - heading to show (on mobile only)
  */
 function feedback(message, duration, heading = t('feedback.header')) {
     if (!support.touch) {

--- a/public/js/src/module/gui.js
+++ b/public/js/src/module/gui.js
@@ -185,12 +185,13 @@ function swapTheme(formParts) {
  *
  * @param { string }  message - message to show
  * @param {number=} duration - duration in seconds for the message to show
+ * @param {string=} duration - heading to show (on mobile only)
  */
-function feedback(message, duration) {
+function feedback(message, duration, heading = t('feedback.header')) {
     if (!support.touch) {
         feedbackBar.show(message, duration);
     } else {
-        alert(message, t('feedback.header'), 'info', duration);
+        alert(message, heading, 'info', duration);
     }
 }
 

--- a/test/client/feedback-bar.spec.js
+++ b/test/client/feedback-bar.spec.js
@@ -1,4 +1,4 @@
-import gui from '../../public/js/src/module/gui';
+import feedbackBar from '../../public/js/src/module/feedback-bar';
 
 const parser = new DOMParser();
 
@@ -26,9 +26,7 @@ describe('Feedback bar', () => {
     });
 
     afterEach(() => {
-        // TODO: much better to call feedbackBar.remove() here (needs to be exposed)
-        feedbackBarEl.querySelectorAll('p').forEach((p) => p.remove());
-        feedbackBarEl.classList.remove(showClass);
+        feedbackBar.hide();
     });
 
     describe('in its original state', () => {
@@ -36,7 +34,7 @@ describe('Feedback bar', () => {
             expect(feedbackBarEl.classList.contains(showClass)).to.equal(false);
         });
         it('is revealed when adding a message', () => {
-            gui.feedback(message1);
+            feedbackBar.show(message1);
             const messageEls = feedbackBarEl.querySelectorAll('p');
 
             expect(feedbackBarEl.classList.contains(showClass)).to.equal(true);
@@ -47,8 +45,8 @@ describe('Feedback bar', () => {
 
     describe('when messages are already shown', () => {
         it('adds a new message before an already added message', () => {
-            gui.feedback(message1);
-            gui.feedback(message2);
+            feedbackBar.show(message1);
+            feedbackBar.show(message2);
             const messageEls = feedbackBarEl.querySelectorAll('p');
 
             expect(feedbackBarEl.classList.contains(showClass)).to.equal(true);
@@ -58,9 +56,9 @@ describe('Feedback bar', () => {
         });
 
         it('removes the oldest message when needed to never show more than 2', () => {
-            gui.feedback(message1);
-            gui.feedback(message2);
-            gui.feedback(message3);
+            feedbackBar.show(message1);
+            feedbackBar.show(message2);
+            feedbackBar.show(message3);
             const messageEls = feedbackBarEl.querySelectorAll('p');
 
             expect(feedbackBarEl.classList.contains(showClass)).to.equal(true);
@@ -73,7 +71,7 @@ describe('Feedback bar', () => {
     describe('hides messages', () => {
         it('with an optional timeout in seconds (simple)', (done) => {
             const time = 1;
-            gui.feedback(message1, time);
+            feedbackBar.show(message1, time);
 
             expect(feedbackBarEl.querySelectorAll('p').length).to.equal(1);
             expect(feedbackBarEl.classList.contains(showClass)).to.equal(true);
@@ -88,8 +86,8 @@ describe('Feedback bar', () => {
         it('with an optional individual timeout per message in seconds', (done) => {
             const time1 = 1;
             const time2 = 0.5;
-            gui.feedback(message1, time1);
-            gui.feedback(message2, time2);
+            feedbackBar.show(message1, time1);
+            feedbackBar.show(message2, time2);
 
             expect(feedbackBarEl.querySelectorAll('p').length).to.equal(2);
             expect(feedbackBarEl.classList.contains(showClass)).to.equal(true);

--- a/test/client/gui.spec.js
+++ b/test/client/gui.spec.js
@@ -1,0 +1,115 @@
+import gui from '../../public/js/src/module/gui';
+
+const parser = new DOMParser();
+
+describe('Feedback bar', () => {
+    const feedbackBarHtml = `
+        <div class="alert-box warning" id="feedback-bar">
+            <span class="icon icon-info-circle"></span>
+            <button class="btn-icon-only close">×</button>
+        </div>`;
+    const showClass = 'feedback-bar--show';
+    const message1 = 'message 1';
+    const message2 = 'message <a href="#" title="this">2</a>';
+    const message3 = 'message 3';
+    let feedbackBarEl;
+
+    before(() => {
+        feedbackBarEl = parser
+            .parseFromString(feedbackBarHtml, 'text/html')
+            .querySelector('#feedback-bar');
+        document.body.appendChild(feedbackBarEl);
+    });
+
+    after(() => {
+        document.body.removeChild(document.querySelector('#feedback-bar'));
+    });
+
+    afterEach(() => {
+        // TODO: much better to call feedbackBar.remove() here (needs to be exposed)
+        feedbackBarEl.querySelectorAll('p').forEach((p) => p.remove());
+        feedbackBarEl.classList.remove(showClass);
+    });
+
+    describe('in its original state', () => {
+        it('is not shown', () => {
+            expect(feedbackBarEl.classList.contains(showClass)).to.equal(false);
+        });
+        it('is revealed when adding a message', () => {
+            gui.feedback(message1);
+            const messageEls = feedbackBarEl.querySelectorAll('p');
+
+            expect(feedbackBarEl.classList.contains(showClass)).to.equal(true);
+            expect(messageEls.length).to.equal(1);
+            expect(messageEls[0].innerHTML).to.equal(message1);
+        });
+    });
+
+    describe('when messages are already shown', () => {
+        it('adds a new message before an already added message', () => {
+            gui.feedback(message1);
+            gui.feedback(message2);
+            const messageEls = feedbackBarEl.querySelectorAll('p');
+
+            expect(feedbackBarEl.classList.contains(showClass)).to.equal(true);
+            expect(messageEls.length).to.equal(2);
+            expect(messageEls[0].innerHTML).to.equal(message2);
+            expect(messageEls[1].innerHTML).to.equal(message1);
+        });
+
+        it('removes the oldest message when needed to never show more than 2', () => {
+            gui.feedback(message1);
+            gui.feedback(message2);
+            gui.feedback(message3);
+            const messageEls = feedbackBarEl.querySelectorAll('p');
+
+            expect(feedbackBarEl.classList.contains(showClass)).to.equal(true);
+            expect(messageEls.length).to.equal(2);
+            expect(messageEls[0].innerHTML).to.equal(message3);
+            expect(messageEls[1].innerHTML).to.equal(message2);
+        });
+    });
+
+    describe('hides messages', () => {
+        it('with an optional timeout in seconds (simple)', (done) => {
+            const time = 1;
+            gui.feedback(message1, time);
+
+            expect(feedbackBarEl.querySelectorAll('p').length).to.equal(1);
+            expect(feedbackBarEl.classList.contains(showClass)).to.equal(true);
+            setTimeout(() => {
+                expect(feedbackBarEl.querySelectorAll('p').length).to.equal(0);
+                expect(feedbackBarEl.classList.contains(showClass)).to.equal(
+                    false
+                );
+                done();
+            }, time * 1000);
+        });
+        it('with an optional individual timeout per message in seconds', (done) => {
+            const time1 = 1;
+            const time2 = 0.5;
+            gui.feedback(message1, time1);
+            gui.feedback(message2, time2);
+
+            expect(feedbackBarEl.querySelectorAll('p').length).to.equal(2);
+            expect(feedbackBarEl.classList.contains(showClass)).to.equal(true);
+
+            setTimeout(() => {
+                const messageEls = feedbackBarEl.querySelectorAll('p');
+                expect(messageEls.length).to.equal(1);
+                expect(messageEls[0].innerHTML).to.equal(message1);
+                expect(feedbackBarEl.classList.contains(showClass)).to.equal(
+                    true
+                );
+            }, time2 * 1000);
+
+            setTimeout(() => {
+                expect(feedbackBarEl.querySelectorAll('p').length).to.equal(0);
+                expect(feedbackBarEl.classList.contains(showClass)).to.equal(
+                    false
+                );
+                done();
+            }, time1 * 1000);
+        });
+    });
+});


### PR DESCRIPTION
Added: ability to call the feedback bar/dialog without an auto-close time-out. Previously the auto-close time-out defaulted to 10 seconds. This ability was needed in an enketo-express fork but seemed best to change here in enketo-express and take the opportunity to refactor the feedback bar and add tests for it.
Fixed: on mobile devices the dialog heading passed to `gui.feedback` was ignored and not shown to user

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Submitting offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [x] None of the above

#### What else has been done to verify that this works as intended?

Tests were added. Those tests were verified to work with the old code as well.

In addition ,closing the feedback bar by clicking the X was tested manually, as well as the bar-to-dialog switching on mobile screens.

I verified that Enketo Express made no calls that relied on the default 10 second time-out. The time-outs are always explicitly passed in calls to `gui.feedback`.

Since these changes are very unlikely to affect any of the above core functionalities they were not tested.

#### Why is this the best possible solution? Were any other approaches considered?

Another approach that was considered (1st commit) was to leave the feedback-bar in gui.js. However, in order to test it properly we'd actually have to expose (export) some additional methods. It seemed cleaner to move it to its own module as we'd have a less confusing interface in the gui module.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There should be no changes to users.

#### Do we need any specific form for testing your changes? If so, please attach one.

No, one way of testing is to expose the `feedback` function in gui.js so it can be called from the command-line (`window.feedback = feedback;`).
