### PR TITLE
Add max processes config value

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,11 +2,14 @@
 /* eslint no-console: ["error", { allow: ["log", "error"] }] */
 
 const cluster = require('cluster');
+const config = require('./app/models/config-model');
 const numCPUs = require('os').cpus().length;
+
+const numProcesses = Math.min(config.server['max processes'], numCPUs);
 
 if (cluster.isMaster) {
     // Fork workers.
-    for (let i = 0; i < numCPUs; i++) {
+    for (let i = 0; i < numProcesses; i++) {
         cluster.fork();
     }
 

--- a/config/default-config.json
+++ b/config/default-config.json
@@ -1,6 +1,7 @@
 {
     "app name": "Enketo Smart Paper for KoBoCAT",
     "port": "8005",
+    "max processes": 16,
     "offline enabled": true,
     "id length": 8,
     "linked form and data server": {

--- a/tutorials/10-configure.md
+++ b/tutorials/10-configure.md
@@ -25,6 +25,10 @@ Just used in home page `"Enketo for [your service name]"`..
 
 The port on which your app is run, e.g. `"8005"`. Any unique assignable port will do. Generally you can leave this alone as you'll use a reverse proxy to map the public port.
 
+#### max processes
+
+The max number of processes Enketo will serve. Enketo will not serve more processes than the number of cpus available. Defaults to `16`.
+
 #### offline enabled
 
 Enable or disable offline functionality. Is either `false` or `true`.


### PR DESCRIPTION
Closes #372

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [x] None of the above

#### What else has been done to verify that this works as intended?

Run application with and without max processes config value specified. Observe console output. I also tested setting it to a string. `"2"` will be interpreted as `2`.

#### Why is this the best possible solution? Were any other approaches considered?

A default of 16 IMO is too high, but it should be safer for legacy purposes. Users who expect a very high process count will only be affected when running on >16 core machines.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Potential (if unlikely) breaking change. A user who expects a very high amount of processes should set the `max processes` config value after updating.

This should benefit developers, who may want to set this to just 1 so as to save on startup time.

#### Do we need any specific form for testing your changes? If so, please attach one.
