### PR TITLE
For offline-capable views, require unique record name + enketo ID and prompt users to edit record name in case of collision

### DIFF
--- a/locales/src/en/translation.json
+++ b/locales/src/en/translation.json
@@ -187,7 +187,7 @@
             "msg": "This action is irreversible. Are you sure you want to proceed?"
         },
         "save": {
-            "existingerror": "This record name or ID already exists.",
+            "existingerror": "This record name or ID already exists. Please change it.",
             "hint": "This name allows you to easily find your draft record to finish it later.",
             "msg": "There are unsaved changes, would you like to continue without saving those?",
             "name": "Record Name",

--- a/public/js/src/module/store.js
+++ b/public/js/src/module/store.js
@@ -45,7 +45,7 @@ function init({ failSilently } = {}) {
         .then(() =>
             db.open({
                 server: databaseName,
-                version: 3,
+                version: 4,
                 schema: {
                     // the surveys
                     surveys: {

--- a/public/js/src/module/store.js
+++ b/public/js/src/module/store.js
@@ -31,6 +31,9 @@ let blobEncoding;
 let available = false;
 
 const databaseName = 'enketo';
+const version = 4;
+
+const REMOVE_RECORD_NAME_UNIQUENESS_VERSION = 4;
 
 /**
  * @typedef StoreInitOptions
@@ -42,10 +45,60 @@ const databaseName = 'enketo';
  */
 function init({ failSilently } = {}) {
     return _checkSupport()
+        .then(() => {
+            // https://github.com/enketo/enketo-express/issues/416
+            // When upgrading from version 3 to 4, ensure that the unique `name` index on
+            // `records` is replaced with an index on the combination `['enketoId', 'name']`.
+            // For any other version upgrades, defer to `db.js`.
+
+            if (version !== REMOVE_RECORD_NAME_UNIQUENESS_VERSION) {
+                return Promise.resolve();
+            }
+
+            return new Promise((resolve, reject) => {
+                const request = indexedDB.open(databaseName, version);
+
+                request.addEventListener('blocked', reject);
+                request.addEventListener('success', resolve);
+                request.addEventListener('error', reject);
+
+                request.addEventListener('upgradeneeded', (event) => {
+                    const { transaction } = request;
+                    try {
+                        if (
+                            event.oldVersion !==
+                                REMOVE_RECORD_NAME_UNIQUENESS_VERSION - 1 ||
+                            event.newVersion !==
+                                REMOVE_RECORD_NAME_UNIQUENESS_VERSION
+                        ) {
+                            // If the *previous* verison was not 3 (e.g. for a new DB),
+                            // these changes will *not* produce the same schema as db.js.
+                            // In those cases, we abort this upgrade and defer to db.js.
+                            // This does leave open the much less likely possibility that
+                            // an upgrade from versions 1 or 2 will leave the `name` index.
+                            transaction.abort();
+
+                            return resolve(event);
+                        }
+
+                        const store = transaction.objectStore('records');
+
+                        // This will produce a schema equivalent to the db.js changes specified
+                        // for version 4.
+                        store.createIndex('recordName', ['enketoId', 'name'], {
+                            unique: true,
+                        });
+                        store.deleteIndex('name');
+                    } catch (error) {
+                        reject(error);
+                    }
+                });
+            });
+        })
         .then(() =>
             db.open({
                 server: databaseName,
-                version: 4,
+                version,
                 schema: {
                     // the surveys
                     surveys: {
@@ -81,15 +134,8 @@ function init({ failSilently } = {}) {
                         },
                         indexes: {
                             // https://github.com/enketo/enketo-express/issues/416
-                            // Version 3 of this database schema had a 'name' index that was set to be unique.
-                            // Although this index was removed in version 4, it will not be automatically deleted in
-                            // existing databases. This is a limitation of db.js. It should not cause significant issues
-                            // as the user will be prompted to edit the record name. Eventually, due to device upgrades,
-                            // or manual indexedDb deletion, this index will probably cease to exist in the world.
-                            //
-                            // to prevent showing the same record name in the queue
                             recordName: {
-                                keyPath: ['name', 'enketoId'],
+                                keyPath: ['enketoId', 'name'],
                                 unique: true,
                             },
                             // the actual key

--- a/public/js/src/module/store.js
+++ b/public/js/src/module/store.js
@@ -80,8 +80,16 @@ function init({ failSilently } = {}) {
                             keyPath: 'instanceId',
                         },
                         indexes: {
-                            // useful to check if name exists
-                            name: {
+                            // https://github.com/enketo/enketo-express/issues/416
+                            // Version 3 of this database schema had a 'name' index that was set to be unique.
+                            // Although this index was removed in version 4, it will not be automatically deleted in
+                            // existing databases. This is a limitation of db.js. It should not cause significant issues
+                            // as the user will be prompted to edit the record name. Eventually, due to device upgrades,
+                            // or manual indexedDb deletion, this index will probably cease to exist in the world.
+                            //
+                            // to prevent showing the same record name in the queue
+                            recordName: {
+                                keyPath: ['name', 'enketoId'],
                                 unique: true,
                             },
                             // the actual key


### PR DESCRIPTION
…than 1 form with the same title exist in the local database, closes #416

Closes #416 

#### I have verified this PR works with

-   [ ] Online form submission
-   [x] Offline form submission
-   [x] Saving offline drafts
-   [x] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [ ] None of the above

#### Why is this the best possible solution? Were any other approaches considered?

Options that were considered:

1 add another postfix (random string 2 or 3 characters) to record name
2 like previous but add the Enketo ID itself as the postfix or prefix (and hide it from the user in the form list?)
3 change database schema to no longer require record name to be unique (we haven't updated a database schema before, might be complicated)
4 like previous but roll our own uniqueness check that only looks at records under the same Enketo ID
5 change database schema to require uniqueness of record name + enketo ID
6 prompt users to edit the record name when this occurs
7 Since the record name is quite irrelevant for a finalized record (since it cannot be opened), we could do one of the above prefixes and postfixes only for finalized records.

I went for a combination of 5 and 6 since that covered the case of the bug report but also some other cases, where users provide their own record name for a draft record that conflicts with an existing record (even for the same form). That issue would remain even if we could completely eliminate the database index bug.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The only issue is that users may end up with a remnant 'name' index in the records table of the browser database until they switch to another device, or browser, or clear storage. However, since the record name prompt feature is now there that will  only be a minor inconvenience.



