### PR TITLE
Allow client csrf cookie name to be configurable

### DIFF
--- a/app/models/config-model.js
+++ b/app/models/config-model.js
@@ -368,6 +368,7 @@ module.exports = {
         validatePage: config['validate page'],
         swipePage: config['swipe page'],
         textMaxChars: config['text field character limit'],
+        csrfCookieName: config['csrf cookie name'],
     },
     getThemesSupported,
 };

--- a/config/default-config.json
+++ b/config/default-config.json
@@ -110,6 +110,7 @@
     "validate page": true,
     "payload limit": "100kb",
     "text field character limit": 2000,
+    "csrf cookie name": "__csrf",
     "frameguard deny": false,
     "no sniff": false,
     "hsts": {

--- a/public/js/src/module/connection.js
+++ b/public/js/src/module/connection.js
@@ -281,10 +281,11 @@ function _prepareFormDataArray(record) {
             'xml_submission_file'
         );
         const csrfToken = (
-            document.cookie.split('; ').find((c) => c.startsWith('__csrf')) ||
-            ''
+            document.cookie
+                .split('; ')
+                .find((c) => c.startsWith(settings.csrfCookieName)) || ''
         ).split('=')[1];
-        if (csrfToken) fd.append('__csrf', csrfToken);
+        if (csrfToken) fd.append(settings.csrfCookieName, csrfToken);
 
         // batch with XML data
         const batchPrepped = {

--- a/tutorials/10-configure.md
+++ b/tutorials/10-configure.md
@@ -243,3 +243,7 @@ Set Content Security Policy (CSP) headers in express. Default is disabled. When 
 -   `enabled`: Default is `false`. Set to `true` to enable CSP headers.
 -   `report only`: Default is `false`. Set to `true` to report, but not enforce, CSP.
 -   `value`: Default is `null`. Set to a custom value to override default CSP value.
+
+#### csrf cookie name
+
+Default is "\_\_csrf". Set to override the cookie name used for a csrf token. This can be helpful to avoid conflicts with other cookies on a domain.


### PR DESCRIPTION
Closes #418

#### I have verified this PR works with

-   [X] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [x] Editing submissions
-   [ ] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?

Submitted form data to kc.kobotoolbox.org

#### Why is this the best possible solution? Were any other approaches considered?

See issue

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This is not a breaking change because the default config retains the __csrf cookie name, which is what most users will likely want 

#### Do we need any specific form for testing your changes? If so, please attach one.

A simple test is to change the cookie name and view it in the browser.

The ultimate test would be to deploy two ee instances to the same subdomain like ee1.example.com and ee2.example.com along with kobocat such as kc1.example.com and kc2.example.com. Without adjusting the domain, it should conflict. After adjusting changing the name of one, it should work. It can be tested by editing a form in kobotoolbox/kpi. 