### PR TITLE
Show a less cryptic error message when form loading fails whilst offline

### DIFF
--- a/locales/src/en/translation.json
+++ b/locales/src/en/translation.json
@@ -217,6 +217,7 @@
         "dataloadfailed": "Failed to load data from __url__",
         "econnrefused": "Could not connect with Form Server",
         "encryptionnotsupported": "This form requires local encryption of records. Unfortunately this is not supported by your browser. We recommend switching to a modern browser.",
+        "formloadfailed": "Failed to load form",
         "instancenotfound": "Record not present. It may have expired.",
         "invalidediturl": "Not a valid edit URL",
         "loadfailed": "Failed to load __resource__",

--- a/public/js/src/module/connection.js
+++ b/public/js/src/module/connection.js
@@ -476,6 +476,12 @@ function getFormParts(props) {
     return _postData(transformURL, {
         xformUrl: props.xformUrl,
     })
+        .catch((error) => {
+            if (error.status === undefined) {
+                error.message = t('error.formloadfailed');
+            }
+            throw error;
+        })
         .then((data) => {
             const model = parser.parseFromString(data.model, 'text/xml');
 
@@ -541,12 +547,7 @@ function _request(url, method = 'POST', data = {}) {
 
     return fetch(url, options)
         .then(_throwResponseError)
-        .then((response) => response.json())
-        .catch((data) => {
-            const error = new Error(data.message);
-            error.status = data.status;
-            throw error;
-        });
+        .then((response) => response.json());
 }
 
 /**


### PR DESCRIPTION
There is an edge condition that shows an unhelpful error message. I can be reproduced by:

1. loading an offline-capable form view, e.g. http://localhost:8005/x/widgets
2. turn off the Enketo server or go offline
3. remove the indexedDb database, e.g. by clicking the button that's hidden behind the version string in the sidebar
4. note the error message

#### What else has been done to verify that this works as intended?

I verified that any formserver-removed forms still show the existing, different and helpful custom message ("This form has been removed or deactivated etc.")

#### Why is this the best possible solution? Were any other approaches considered?

This seemed to me the only way to do this without interfering with other error messages.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

In situations where the cached Enketo app fails to download a form, when it is offline (and in some other cases perhaps). The error message shown is "Failed to fetch".

<img width="615" alt="Screen Shot 2022-05-10 at 4 40 03 PM" src="https://user-images.githubusercontent.com/627350/167717976-60c6fb68-85e9-479b-8cde-a16ddbffff9d.png">


This PR changes that into a more helpful message:

<img width="577" alt="Screen Shot 2022-05-10 at 3 17 04 PM" src="https://user-images.githubusercontent.com/627350/167716847-58327ae0-0ee8-40ff-8784-b00964f5f57f.png">

#### Do we need any specific form for testing your changes? If so, please attach one.

No, any offline-capable form view will work, e.g. http://localhost:8005/x/widgets
