### PR TITLE
Use a more helpful error message if external data is missing in non-preview views

### DIFF
--- a/locales/src/en/translation.json
+++ b/locales/src/en/translation.json
@@ -214,7 +214,7 @@
     },
     "error": {
         "code": "Error Code: __code__",
-        "dataloadfailed": "Failed to load data from __url__",
+        "dataloadfailed": "Failed to load __filename__.",
         "econnrefused": "Could not connect with Form Server",
         "encryptionnotsupported": "This form requires local encryption of records. Unfortunately this is not supported by your browser. We recommend switching to a modern browser.",
         "formloadfailed": "Failed to load form",

--- a/public/js/src/module/connection.js
+++ b/public/js/src/module/connection.js
@@ -656,10 +656,6 @@ function getDataFile(url, languageMap) {
                 !error.message || /fetch/.test(error.message)
                     ? t('error.dataloadfailed', {
                           filename: url.replace(/.*\//, ''),
-                          // switch off escaping just for this known safe value
-                          interpolation: {
-                              escapeValue: false,
-                          },
                       })
                     : error.message;
             throw new Error(errorMsg);

--- a/public/js/src/module/connection.js
+++ b/public/js/src/module/connection.js
@@ -653,14 +653,15 @@ function getDataFile(url, languageMap) {
         })
         .catch((error) => {
             const errorMsg =
-                error.message ||
-                t('error.dataloadfailed', {
-                    url,
-                    // switch off escaping just for this known safe value
-                    interpolation: {
-                        escapeValue: false,
-                    },
-                });
+                !error.message || /fetch/.test(error.message)
+                    ? t('error.dataloadfailed', {
+                          filename: url.replace(/.*\//, ''),
+                          // switch off escaping just for this known safe value
+                          interpolation: {
+                              escapeValue: false,
+                          },
+                      })
+                    : error.message;
             throw new Error(errorMsg);
         });
 }


### PR DESCRIPTION
…ow useful error messages

Closes #422

For discussion: 
Would it be best to just treat previews the same as non-previews wrt missing external data? This would mean showing a helpful error message for each missing instance (as well any other loading errors). This PR assumes so, but I am happy to change that and show a single error message, and cease form loading for non-previews (e.g. referencing just the first missing instance or a generic "Can't find external data").

One argument for not making the distinction between previews and non-previews is that a form may pass preview testing (e.g. using a `form` query parameter) perfectly but the administrator forgets to attach external data files when launching it (e.g. in a different account).

Fwiw, OpenClinica makes a (simple) distinction between serious and non-serious loading errors and removes submit buttons in non-preview views. [See code here](https://github.com/OpenClinica/enketo-express-oc/blob/master/public/js/src/module/controller-webform-oc.js#L328). The equivalent for this repo would be to just exclude goTo errors. However, we do already have the message "We do not recommend you use this form for data entry until this is resolved." (which OpenClinica doesn't have). Maybe that message is sufficient?

#### I have verified this PR works with

-   [x] Online form submission
-   [x] Offline form submission
-   [x] Saving offline drafts
-   [x] Loading offline drafts
-   [ ] Editing submissions
-   [x] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?

In offline-capable views, I verified that a missing external data file (in indexedDb) can be 'healed' by the survey administrator making that file available.

#### Why is this the best possible solution? Were any other approaches considered?

A more minimal approach would have to mean to maintain the distinction between previews and non-previews, and to terminate loading when the first data file fails to load.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The risk is that a user may ignore the warning dialog and try to submit a record even though an external data file is missing.

#### Do we need any specific form for testing your changes? If so, please attach one.

See #422 for a form.

The result for a regular non-preview form is (diffs: form is now shown, and 2 specific error messages are shown):

<img width="896" alt="Screen Shot 2022-05-12 at 4 26 39 PM" src="https://user-images.githubusercontent.com/627350/168162225-6a6a2e90-d5eb-4798-96e0-6c86df1fda88.png">

