### PR TITLE
Fix/missing media healing offline 419

### DIFF
--- a/public/js/src/module/form-cache.js
+++ b/public/js/src/module/form-cache.js
@@ -303,13 +303,13 @@ function updateMaxSubmissionSize(survey) {
  * @return { Promise<Survey> }
  */
 function updateMedia(survey) {
-    const targetContainers = [document.querySelector('form.or')];
+    const containers = [document.querySelector('form.or')];
     const formHeader = document.querySelector('.form-header');
     if (formHeader) {
-        targetContainers.push(formHeader);
+        containers.push(formHeader);
     }
 
-    return _loadMedia(survey, targetContainers)
+    return _loadMedia(survey, containers)
         .then((resources) => {
             // if all resources were already in the database, _loadMedia returned undefined
             if (resources) {
@@ -346,6 +346,12 @@ function _reflect(task) {
         }
     );
 }
+
+/**
+ * @typedef Resource
+ * @property {string} url URL to resource
+ * @property {Blob} item resource as Blob
+ */
 
 /**
  * Loads and displays survey resources either from the store or via HTTP.

--- a/test/client/form-cache.spec.js
+++ b/test/client/form-cache.spec.js
@@ -284,7 +284,9 @@ describe('Client Form Cache', () => {
 
             beforeEach((done) => {
                 getFileSpy.restore();
-                getFileSpy = sandbox.stub(connection, 'getMediaFile').throws();
+                getFileSpy = sandbox
+                    .stub(connection, 'getMediaFile')
+                    .callsFake(() => Promise.reject(new Error('Fail!')));
 
                 storeSurveyUpdateSpy = sandbox.spy(store.survey, 'update');
 


### PR DESCRIPTION
Closes #419

#### I have verified this PR works with

-   [x] Offline form-with-media loading, in particular these cases:

1. a media file fails to load the first time the form is cached
2. newly added repeats will show cached media files correctly

#### What else has been done to verify that this works as intended?

Some tests were added.

#### Why is this the best possible solution? Were any other approaches considered?

It seems the most efficient way for an offline-capable view to recover from failed-to-download (due to large size, poor Internet) media files.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Users will be happier. This is intentional. Regressions risks maybe for some unidentified edge cases with form media.

#### Do we need any specific form for testing your changes? If so, please attach one.

Any form will media will do. I put a curl snippet in the issue.
