### PR TITLE
Fix: don't escape HTML entities in alert dialogs

### DIFF
--- a/public/js/src/module/gui.js
+++ b/public/js/src/module/gui.js
@@ -7,13 +7,13 @@ import support from 'enketo-core/src/js/support';
 import * as printHelper from 'enketo-core/src/js/print';
 import vex from 'vex-js';
 import $ from 'jquery';
+import vexEnketoDialog from 'vex-dialog-enketo';
 import feedbackBar from './feedback-bar';
 import settings from './settings';
 import { init as initTranslator, t } from './translator';
 import sniffer from './sniffer';
 import events from './event';
 import './plugin';
-import vexEnketoDialog from 'vex-dialog-enketo';
 
 let pages;
 let homeScreenGuidance;
@@ -208,7 +208,7 @@ function alert(message, heading, level, duration) {
     level = level || 'error';
     vex.closeAll();
     vex.dialog.alert({
-        unsafeMessage: message,
+        unsafeMessage: `<span>${message}</span>`,
         title: heading || t('alert.default.heading'),
         messageClassName: level === 'normal' ? '' : `alert-box ${level}`,
         buttons: [

--- a/test/client/gui.spec.js
+++ b/test/client/gui.spec.js
@@ -1,0 +1,28 @@
+import gui from '../../public/js/src/module/gui';
+
+describe('Alert dialogs', () => {
+    /** @type {HTMLElement | null} */
+    let dialog;
+
+    beforeEach(() => {
+        dialog = null;
+    });
+
+    afterEach(() => {
+        if (dialog != null) {
+            const overlay = document.querySelector('.vex-overlay');
+
+            dialog.remove();
+            overlay.remove();
+        }
+    });
+
+    it('does not escape HTML entities in translations', () => {
+        gui.alert('&egrave;');
+
+        dialog = document.querySelector('.vex');
+
+        expect(dialog.innerText).to.include('è');
+        expect(dialog.innerText).not.to.include('&egrave;');
+    });
+});

--- a/test/client/gui.spec.js
+++ b/test/client/gui.spec.js
@@ -17,12 +17,28 @@ describe('Alert dialogs', () => {
         }
     });
 
-    it('does not escape HTML entities in translations', () => {
-        gui.alert('&egrave;');
+    const entities = {
+        '&agrave;': 'à',
+        '&eacute;': 'é',
+        '&igrave;': 'ì',
+        '&ograve;': 'ò',
+        '&ugrave;': 'ù',
+        '&Agrave;': 'À',
+        '&Eacute;': 'É',
+        '&Egrave;': 'È',
+        '&Igrave;': 'Ì',
+        '&Ograve;': 'Ò',
+        '&Ugrave;': 'Ù',
+    };
 
-        dialog = document.querySelector('.vex');
+    Object.entries(entities).forEach(([entity, expected]) => {
+        it('does not escape HTML entities in translations', () => {
+            gui.alert(entity);
 
-        expect(dialog.innerText).to.include('è');
-        expect(dialog.innerText).not.to.include('&egrave;');
+            dialog = document.querySelector('.vex');
+
+            expect(dialog.innerText).to.include(expected);
+            expect(dialog.innerText).not.to.include(entity);
+        });
     });
 });


### PR DESCRIPTION
Closes #439 

#### I have verified this PR works with

-   [ ] Online form submission
-   [x] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?

Manual verification.

#### Why is this the best possible solution? Were any other approaches considered?

It's probably not a great solution. This works around the behavior of the vex dialog library, and the underlying domify library. When called with a plain string, it appends the string to the DOM which automatically escapes it. By wrapping in a span tag, it inserts as raw HTML.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It's a potential XSS vulnerability, but the intent of the code prior to this change was to allow for that.

#### Do we need any specific form for testing your changes? If so, please attach one.

See #439