### PR TITLE
Fix: memory leak with async_hooks request context

### DIFF
--- a/app/lib/context.js
+++ b/app/lib/context.js
@@ -16,6 +16,10 @@ const requestContextMiddleware = (req, res, next) => {
 
         baseContext.set('request', req);
 
+        res.once('finish', () => {
+            baseContext.set('request', null);
+        });
+
         next();
     });
 };


### PR DESCRIPTION
Closes #443. Thanks to @noliveleger for filing the issue and identifying the root cause!

#### I have verified this PR works with

-   [x] Online form submission
-   [x] Offline form submission
-   [x] Saving offline drafts
-   [x] Loading offline drafts
-   [x] Editing submissions
-   [x] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?

1. Set the local dev environment to use the Node flag `--expose-gc`.
2. Added `setInterval(() => gc(), 1000)` for consistent observation of memory usage before/after the change.
3. Created a local API endpoint which does nothing other than reference `getCurrentRequest` during a request/response cycle.
4. Send a bunch of `fetch` requests to that endpoint every ~200ms.
6. Watch memory usage steadily grow with the current implementation (about 1 MB every few seconds).
7. Watch memory usage plateau[^1] with the change in this PR.

[^1]: Roughly. This manual testing approach left all other aspects of the server environment intact. Something else appears to occasionally leak memory, but so much more slowly I wasn't concerned enough to look into it any further.

#### Why is this the best possible solution? Were any other approaches considered?

It's definitely not the best possible solution. Continuation Local Storage (whether using async hooks or not) isn't a great idea in the first place. But this addresses the current issue with minimal disruption.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This should improve reliability of Enketo Express service deployments, but otherwise should have no impact on users.

#### Do we need any specific form for testing your changes? If so, please attach one.

N/A