### PR TITLE
Add redis-repl tool

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -75,7 +75,12 @@
         },
 
         {
-            "files": ["app.js", "app/**/*.js", "!app/views/**/*.js"],
+            "files": [
+                "app.js",
+                "app/**/*.js",
+                "!app/views/**/*.js",
+                "tools/redis-repl"
+            ],
             "env": {
                 "browser": false,
                 "node": true

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ logs/logrotate
 test-coverage
 coverage.shield.badge.md
 _drafts
+/tools/.redis-repl.history

--- a/tools/redis-repl
+++ b/tools/redis-repl
@@ -1,0 +1,81 @@
+#!/usr/bin/env -S NODE_ENV=development node
+const redis = require('redis');
+const redisVersion = require('../node_modules/redis/package.json').version;
+const config = require('../app/models/config-model').server.redis.main;
+const { REPLServer } = require('repl');
+
+const log = (...args) => console.error('[redis-repl]', ...args);
+
+log(`Connecting to redis at ${config.host}:${config.port}...`);
+const client = redis.createClient(config.port, config.host, { auth_pass: config.password });
+client.on('error', (err) => log('Redis client error:', err));
+client.on('end', () => log('Redis client closed') || process.exit());
+
+client.on('connect', async () => {
+  log('Connected.');
+
+  const predefs = [
+    [ client,     'client',   'client',     'Redis client.' ],
+    [ listKeys,   'listKeys', 'listKeys()', 'Show all keys in the database.' ],
+    [ get,        'get',      'get(id)',    'Get something from the database.' ],
+    [ printUsage, 'help',     'help()',     'Show this message.' ],
+  ];
+
+  printUsage();
+
+  const repl = new REPLServer({ prompt:'redis> ' });
+  repl.on('exit', () => client.end(true));
+
+  await new Promise((resolve, reject) => repl.setupHistory('tools/.redis-repl.history', err => err ? reject(err) : resolve()));
+
+  predefs
+      .forEach(([ value, varName ]) => {
+        repl.context[varName] = value;
+      });
+
+  function printUsage() {
+    console.log(`\nnode-redis docs: https://github.com/redis/node-redis/tree/v${redisVersion}#usage`);
+
+    console.log('\nAvailable globals:\n');
+    const cmdPad = 1 + predefs.reduce((acc, p) => Math.max(acc, p[2].length), 0);
+    predefs
+        .forEach(([ , , cmd, description ]) => {
+          console.log(' ', cmd.padEnd(cmdPad, ' '), description);
+        });
+    console.log();
+  }
+
+  function get(id) {
+    replCmd(
+      wrapper => client.hgetall('ca:localhost:8989/v1/projects/1,withrepeat', wrapper),
+      res => console.log(res),
+    );
+  }
+
+  function listKeys() {
+    replCmd(
+      wrapper => client.multi().keys('*').exec(wrapper),
+      ([ keys ]) => {
+        keys.sort();
+
+        console.log('\n\nKeys in database:\n');
+        keys.forEach(k => console.log(' ', k));
+        console.log();
+      },
+    );
+  }
+
+  function replCmd(fn, resultHandler) {
+    repl.clearBufferedCommand();
+    fn((err, res) => {
+      if(err) {
+        log('Error:', err);
+        repl.displayPrompt();
+        return;
+      }
+
+      resultHandler(res);
+      repl.displayPrompt();
+    });
+  }
+});

--- a/tools/redis-repl
+++ b/tools/redis-repl
@@ -72,7 +72,7 @@ client.on('connect', async () => {
       return console.log('This is the total count of form submissions to this enketo-express instance.');
     }
     switch(key.split(':')[0]) {
-      case 'ca': return console.log('ca:<open-rosa-server>,<open-rosa-id>  Cached Enketo SurveyObject.');
+      case 'ca': return console.log('ca:<open-rosa-server>,<open-rosa-id>  enketo-transformer result.');
       case 'or': return console.log('or:<open-rosa-server>,<open-rosa-id>  Enketo ID.');
       case 'id': return console.log('id:<enketo-id>  Enketo SurveyObject.');
       case 'su': return console.log('su:<enketo-id>  Submission IDs.');

--- a/tools/redis-repl
+++ b/tools/redis-repl
@@ -69,13 +69,13 @@ client.on('connect', async () => {
 
   function describeKey(key) {
     if(key === 'submission:counter') {
-      return console.log('This is the total count of form submissions to this enketo-express instance.');
+      return console.log('key: submission:counter  value: total count of form submissions to this enketo-express instance.');
     }
     switch(key.split(':')[0]) {
-      case 'ca': return console.log('ca:<open-rosa-server>,<open-rosa-id>  enketo-transformer result.');
-      case 'or': return console.log('or:<open-rosa-server>,<open-rosa-id>  Enketo ID.');
-      case 'id': return console.log('id:<enketo-id>  Enketo SurveyObject.');
-      case 'su': return console.log('su:<enketo-id>  Submission IDs.');
+      case 'ca': return console.log('key: ca:<open-rosa-id>  value: enketo-transformer result');
+      case 'or': return console.log('key: or:<open-rosa-id>  value: Enketo ID');
+      case 'id': return console.log('key: id:<enketo-id>     value: Enketo SurveyObject');
+      case 'su': return console.log('key: su:<enketo-id>     value: Submission IDs');
       default: throw new Error(`No description yet for keys like: '${key}'`);
     }
   }

--- a/tools/redis-repl
+++ b/tools/redis-repl
@@ -1,113 +1,245 @@
-#!/usr/bin/env -S NODE_ENV=development node
-const redis = require('redis');
-const redisVersion = require('../node_modules/redis/package.json').version;
-const config = require('../app/models/config-model').server.redis.main;
+#!/usr/bin/env node
+
+process.env.NODE_ENV = 'development';
+
 const { REPLServer } = require('repl');
+const redisVersion = require('../node_modules/redis/package.json').version;
+const { cacheClient, mainClient } = require('../app/lib/db');
 
 const log = (...args) => console.error('[redis-repl]', ...args);
 
-log(`Connecting to redis at ${config.host}:${config.port}...`);
-const client = redis.createClient(config.port, config.host, { auth_pass: config.password });
-client.on('error', (err) => log('Redis client error:', err));
-client.on('end', () => log('Redis client closed') || process.exit());
+const clients = [mainClient];
 
-client.on('connect', async () => {
-  log('Connected.');
+if (
+    cacheClient.options.host !== mainClient.options.host ||
+    cacheClient.options.port !== mainClient.options.port
+) {
+    clients.push(cacheClient);
+}
 
-  const predefs = [
-    [ client,      'client',   'client',         'Redis client.' ],
-    [ listKeys,    'listKeys', 'listKeys()',     'Show all keys in the database.' ],
-    [ get,         'get',      'await get(key)', 'Get something from the database.' ],
-    [ describeKey, 'describe', 'describe(key)',  'Get something from the database.' ],
-    [ printUsage,  'help',     'help()',         'Show this message.' ],
-  ];
+const init = async () => {
+    await Promise.all(
+        clients.map(
+            (client) =>
+                new Promise((resolve, reject) => {
+                    log(
+                        `Connecting to redis at ${client.options.host}:${client.options.port}...`
+                    );
 
-  printUsage();
+                    const onConnect = () => {
+                        resolve();
+                        cleanup();
+                    };
+                    const onError = (error) => {
+                        reject(error);
+                        cleanup();
+                    };
+                    const cleanup = () => {
+                        client.removeListener('connect', onConnect);
+                        client.removeListener('error', onError);
+                    };
 
-  const repl = new REPLServer({ prompt:'redis> ' });
-  repl.on('exit', () => client.end(true));
-
-  await new Promise((resolve, reject) => repl.setupHistory('tools/.redis-repl.history', err => err ? reject(err) : resolve()));
-
-  predefs
-      .forEach(([ value, varName ]) => {
-        repl.context[varName] = value;
-      });
-
-  function printUsage() {
-    console.log(`\nnode-redis docs: https://github.com/redis/node-redis/tree/v${redisVersion}#usage`);
-
-    console.log('\nAvailable globals:\n');
-    const cmdPad = 1 + predefs.reduce((acc, p) => Math.max(acc, p[2].length), 0);
-    predefs
-        .forEach(([ , , cmd, description ]) => {
-          console.log(' ', cmd.padEnd(cmdPad, ' '), description);
-        });
-    console.log();
-  }
-
-  function get(key) {
-    return replCmd(
-      wrapper => {
-        if(key === 'submission:counter') {
-          return client.get(key, wrapper);
-        }
-        switch(key.split(':')[0]) {
-          case 'ca':
-          case 'id':
-            return client.hgetall(key, wrapper);
-          case 'su':
-            return client.lrange(key, 0, -1, wrapper);
-          case 'or':
-            return client.get(key, wrapper);
-          default: throw new Error(`No handling yet for keys like: '${key}'`);
-        }
-      },
-      res => res,
+                    client.on('connect', onConnect);
+                    client.on('error', onError);
+                })
+        )
     );
-  }
 
-  function describeKey(key) {
-    if(key === 'submission:counter') {
-      return console.log('key: submission:counter  value: total count of form submissions to this enketo-express instance.');
-    }
-    switch(key.split(':')[0]) {
-      case 'ca': return console.log('key: ca:<open-rosa-id>  value: enketo-transformer result');
-      case 'or': return console.log('key: or:<open-rosa-id>  value: Enketo ID');
-      case 'id': return console.log('key: id:<enketo-id>     value: Enketo SurveyObject');
-      case 'su': return console.log('key: su:<enketo-id>     value: Submission IDs');
-      default: throw new Error(`No description yet for keys like: '${key}'`);
-    }
-  }
+    log('Connected.');
 
-  function listKeys() {
-    return replCmd(
-      wrapper => client.multi().keys('*').exec(wrapper),
-      ([ keys ]) => {
+    clients.forEach((client) => {
+        client.on('error', (err) => log('Redis client error:', err));
+        client.on('end', () => log('Redis client closed') || process.exit());
+    });
+
+    const clientCommands =
+        clients.length === 1
+            ? [
+                  {
+                      varName: 'client',
+                      value: mainClient,
+                      command: 'client',
+                      description: 'Redis client.',
+                  },
+              ]
+            : [
+                  {
+                      varName: 'mainClient',
+                      value: mainClient,
+                      command: 'mainClient',
+                      description: 'Redis main client.',
+                  },
+                  {
+                      varName: 'cacheClient',
+                      value: cacheClient,
+                      command: 'cacheClient',
+                      description: 'Redis cache client.',
+                  },
+              ];
+
+    const predefs = [
+        ...clientCommands,
+        {
+            varName: 'listKeys',
+            value: listKeys,
+            command: 'await listKeys()',
+            description: 'Show all keys in the database.',
+        },
+        {
+            varName: 'get',
+            value: get,
+            command: 'await get(key)',
+            description: 'Get something from the database.',
+        },
+        {
+            varName: 'describe',
+            value: describeKey,
+            command: 'describe(key)',
+            description: 'Get something from the database.',
+        },
+        {
+            varName: 'help',
+            value: printUsage,
+            command: 'help()',
+            description: 'Show this message.',
+        },
+    ];
+
+    printUsage();
+
+    const repl = new REPLServer({ prompt: 'redis> ' });
+
+    repl.on('exit', () => {
+        clients.forEach((client) => {
+            client.end(true);
+        });
+    });
+
+    function printUsage() {
+        console.log(
+            `\nnode-redis docs: https://github.com/redis/node-redis/tree/v${redisVersion}#usage`
+        );
+
+        console.log('\nAvailable globals:\n');
+
+        const cmdPad =
+            1 + predefs.reduce((acc, p) => Math.max(acc, p.command.length), 0);
+
+        predefs.forEach(({ command, description }) => {
+            console.log(' ', command.padEnd(cmdPad, ' '), description);
+        });
+        console.log();
+    }
+
+    function get(key) {
+        return replCmd(
+            (wrapper) => {
+                if (key === 'submission:counter') {
+                    return mainClient.get(key, wrapper);
+                }
+                switch (key.split(':')[0]) {
+                    case 'ca':
+                        if (key.includes('/media/get/')) {
+                            return cacheClient.get(key, wrapper);
+                        }
+
+                        return cacheClient.hgetall(key, wrapper);
+                    case 'id':
+                    case 'in':
+                        return mainClient.hgetall(key, wrapper);
+                    case 'su':
+                        return mainClient.lrange(key, 0, -1, wrapper);
+                    case 'or':
+                        return mainClient.get(key, wrapper);
+                    default:
+                        throw new Error(
+                            `No handling yet for keys like: '${key}'`
+                        );
+                }
+            },
+            (res) => res
+        );
+    }
+
+    function describeKey(key) {
+        if (key === 'submission:counter') {
+            return console.log(
+                'key: submission:counter  value: total count of form submissions to this enketo-express instance.'
+            );
+        }
+
+        switch (key.split(':')[0]) {
+            case 'ca':
+                return console.log(
+                    'key: ca:<open-rosa-id>  value: enketo-transformer result'
+                );
+            case 'or':
+                return console.log('key: or:<open-rosa-id>  value: Enketo ID');
+            case 'id':
+                return console.log(
+                    'key: id:<enketo-id>     value: Enketo SurveyObject'
+                );
+            case 'in':
+                return console.log('key: in:<submission-id> value: Submission');
+            case 'su':
+                return console.log(
+                    'key: su:<enketo-id>     value: Submission IDs'
+                );
+            default:
+                throw new Error(`No description yet for keys like: '${key}'`);
+        }
+    }
+
+    async function listKeys() {
+        const keys = (
+            await Promise.all(
+                clients.map((client) =>
+                    replCmd(
+                        (wrapper) => client.multi().keys('*').exec(wrapper),
+                        ([results]) => results
+                    )
+                )
+            )
+        ).flat(2);
+
         keys.sort();
 
-        console.log('\n\nKeys in database:\n');
-        keys.forEach(k => console.log(' ', k));
-        console.log();
-      },
+        [
+            '',
+            '',
+            'Keys in database:',
+            '',
+            ...keys.sort().map((key) => ` ${key}`),
+        ].forEach((line) => console.log(line));
+    }
+
+    function replCmd(fn, resultHandler) {
+        return new Promise((resolve, reject) => {
+            repl.clearBufferedCommand();
+            fn((err, res) => {
+                if (err) {
+                    log('Error:', err);
+                    repl.displayPrompt();
+                    return reject(err);
+                }
+
+                resultHandler(res);
+                repl.displayPrompt();
+
+                return resolve(res);
+            });
+        });
+    }
+
+    await new Promise((resolve, reject) =>
+        repl.setupHistory('tools/.redis-repl.history', (err) =>
+            err ? reject(err) : resolve()
+        )
     );
-  }
 
-  function replCmd(fn, resultHandler) {
-    return new Promise((resolve, reject) => {
-      repl.clearBufferedCommand();
-      fn((err, res) => {
-        if(err) {
-          log('Error:', err);
-          repl.displayPrompt();
-          return reject(err);
-        }
-
-        resultHandler(res);
-        repl.displayPrompt();
-
-        return resolve(res);
-      });
+    predefs.forEach(({ value, varName }) => {
+        repl.context[varName] = value;
     });
-  }
-});
+};
+
+init();

--- a/tools/redis-repl
+++ b/tools/redis-repl
@@ -15,10 +15,11 @@ client.on('connect', async () => {
   log('Connected.');
 
   const predefs = [
-    [ client,     'client',   'client',     'Redis client.' ],
-    [ listKeys,   'listKeys', 'listKeys()', 'Show all keys in the database.' ],
-    [ get,        'get',      'get(id)',    'Get something from the database.' ],
-    [ printUsage, 'help',     'help()',     'Show this message.' ],
+    [ client,      'client',   'client',         'Redis client.' ],
+    [ listKeys,    'listKeys', 'listKeys()',     'Show all keys in the database.' ],
+    [ get,         'get',      'await get(key)', 'Get something from the database.' ],
+    [ describeKey, 'describe', 'describe(key)',  'Get something from the database.' ],
+    [ printUsage,  'help',     'help()',         'Show this message.' ],
   ];
 
   printUsage();
@@ -45,15 +46,42 @@ client.on('connect', async () => {
     console.log();
   }
 
-  function get(id) {
-    replCmd(
-      wrapper => client.hgetall('ca:localhost:8989/v1/projects/1,withrepeat', wrapper),
-      res => console.log(res),
+  function get(key) {
+    return replCmd(
+      wrapper => {
+        if(key === 'submission:counter') {
+          return client.get(key, wrapper);
+        }
+        switch(key.split(':')[0]) {
+          case 'ca':
+          case 'id':
+            return client.hgetall(key, wrapper);
+          case 'su':
+            return client.lrange(key, 0, -1, wrapper);
+          case 'or':
+            return client.get(key, wrapper);
+          default: throw new Error(`No handling yet for keys like: '${key}'`);
+        }
+      },
+      res => res,
     );
   }
 
+  function describeKey(key) {
+    if(key === 'submission:counter') {
+      return console.log('This is the total count of form submissions to this enketo-express instance.');
+    }
+    switch(key.split(':')[0]) {
+      case 'ca': return console.log('ca:<open-rosa-server>,<open-rosa-id>  Cached Enketo SurveyObject.');
+      case 'or': return console.log('or:<open-rosa-server>,<open-rosa-id>  Enketo ID.');
+      case 'id': return console.log('id:<enketo-id>  Enketo SurveyObject.');
+      case 'su': return console.log('su:<enketo-id>  Submission IDs.');
+      default: throw new Error(`No description yet for keys like: '${key}'`);
+    }
+  }
+
   function listKeys() {
-    replCmd(
+    return replCmd(
       wrapper => client.multi().keys('*').exec(wrapper),
       ([ keys ]) => {
         keys.sort();
@@ -66,16 +94,20 @@ client.on('connect', async () => {
   }
 
   function replCmd(fn, resultHandler) {
-    repl.clearBufferedCommand();
-    fn((err, res) => {
-      if(err) {
-        log('Error:', err);
-        repl.displayPrompt();
-        return;
-      }
+    return new Promise((resolve, reject) => {
+      repl.clearBufferedCommand();
+      fn((err, res) => {
+        if(err) {
+          log('Error:', err);
+          repl.displayPrompt();
+          return reject(err);
+        }
 
-      resultHandler(res);
-      repl.displayPrompt();
+        resultHandler(res);
+        repl.displayPrompt();
+
+        return resolve(res);
+      });
     });
   }
 });


### PR DESCRIPTION
Sharing in case it's interesting: a little tool I built to help explore the contents of the redis store that enketo-express connects to.

Example session:

```javascript
$ ./tools/redis-repl 
[redis-repl] Connecting to redis at 127.0.0.1:6379...
[redis-repl] Connected.

node-redis docs: https://github.com/redis/node-redis/tree/v3.1.2#usage

Available globals:

  client          Redis client.
  listKeys()      Show all keys in the database.
  await get(key)  Get something from the database.
  describe(key)   Get something from the database.
  help()          Show this message.

redis> describe('su:2jCCSuaf')
key: su:<enketo-id>     value: Submission IDs
undefined
redis> await get('su:2jCCSuaf')
redis> [
  'uuid:3b0d7bce-eff1-472d-8e6a-c3e2be51d9a4',
  'uuid:388d1107-d87c-4bcf-90b7-f622d4532458',
  'uuid:388d1107-d87c-4bcf-90b7-f622d4518825',
  'uuid:388d1107-d87c-4bcf-90b7-f622d4516471',
  'uuid:388d1107-d87c-4bcf-90b7-f622d4519513',
  'uuid:388d1107-d87c-4bcf-90b7-f622d4528766',
  'uuid:388d1107-d87c-4bcf-90b7-f622d4525074',
  'uuid:388d1107-d87c-4bcf-90b7-f622d4518104',
  'uuid:388d1107-d87c-4bcf-90b7-f622d454173',
  'uuid:388d1107-d87c-4bcf-90b7-f622d4511643',
  'uuid:388d1107-d87c-4bcf-90b7-f622d4577347',
  'uuid:e1eae6a8-5cde-4c73-8fdf-51ee26ddfa56'
]
redis> 
```