### PR TITLE
removed: absolute maximum size for file uploads

### DIFF
--- a/public/js/src/module/connection.js
+++ b/public/js/src/module/connection.js
@@ -58,7 +58,6 @@ const MAX_SIZE_URL = settings.enketoId
     : `${settings.basePath}/submission/max-size/?xformUrl=${encodeURIComponent(
           settings.xformUrl
       )}`;
-const ABSOLUTE_MAX_SIZE = 100 * 1000 * 1000;
 
 /**
 /**
@@ -372,10 +371,7 @@ function getMaximumSubmissionSize(survey) {
         .then((response) => response.json())
         .then((data) => {
             if (data && data.maxSize && !isNaN(data.maxSize)) {
-                survey.maxSize =
-                    Number(data.maxSize) > ABSOLUTE_MAX_SIZE
-                        ? ABSOLUTE_MAX_SIZE
-                        : Number(data.maxSize);
+                survey.maxSize = Number(data.maxSize);
             } else {
                 console.error(
                     'Error retrieving maximum submission size. Unexpected response: ',


### PR DESCRIPTION
We had a hardcoded absolute max file size of 100 MB that would overwrite a higher value that a form server says it can handle (by returning an `X-OpenRosa-Accept-Content-Length` header). E.g. if a form server says it can handle 150 MB, Enketo would ignore this and only allow 100 MB per file. OpenClinica would like to be able to increase file uploads to more than 100 MB.

There are three cases to consider:

A. A form/data server linked to its own Enketo server does not return an `X-OpenRosa-Accept-Content-Length` header. File uploads will continue to be limited to the default of 5 MB as they were before.

B. A form/data server linked to its own Enketo server returns an `X-OpenRosa-Accept-Content-Length` header. In that case that server probably has good reasons for using that value. 

C. An Enketo server is linked with form/data servers that it has no control over and it wants to prevent massive file uploads to manage its resources. I think this is the reason we have the hardcoded absolute max size in the current code as this case applies to Enketo LLC's SaaS service.

#### I have verified this PR works with

-  [x] a form server that does not return an `X-OpenRosa-Accept-Content-Length` header 
-  [x] a form server that returns an `X-OpenRosa-Accept-Content-Length` header  with a value higher than 100 Mb

#### What else has been done to verify that this works as intended?

nothing

#### Why is this the best possible solution? Were any other approaches considered?

An alternative approach would be to make the absolute maximum configurable by moving it to config.json. If scenario C only applies to my little (slowly dying with ODK Aggregate) SaaS business, the benefits don't seem worth it and I prefer the simpler solution in this PR (i.e. removing the absolute maximum entirely).

Another approach would be to raise the value from 100 MB to say 200 MB. However, that is not a real solution and will probably require another update in the future.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The only impact on users would be a potentially higher file upload limit.

