### PR TITLE
Dockerfile: use npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install -g grunt-cli pm2
 
 COPY . ${ENKETO_SRC_DIR}
 
-RUN npm install && grunt && npm prune --production
+RUN npm clean-install && grunt && npm prune --production
 
 # Persist the `secrets` directory so the encryption key remains consistent.
 RUN mkdir -p ${ENKETO_SRC_DIR}/setup/docker/secrets


### PR DESCRIPTION
> This command is similar to npm install, except it's meant to be used
> in automated environments such as test platforms, continuous
> integration, and deployment -- or any situation where you want to
> make sure you're doing a clean install of your dependencies.
>
> - https://docs.npmjs.com/cli/v8/commands/npm-ci/
