### PR TITLE
Fix: fail early on non-multipart submissions

### DIFF
--- a/app/controllers/submission-controller.js
+++ b/app/controllers/submission-controller.js
@@ -47,11 +47,25 @@ router
  * Simply pipes well-formed request to the OpenRosa server and
  * copies the response received.
  *
- * @param {module:api-controller~ExpressRequest} req - HTTP request
- * @param {module:api-controller~ExpressResponse} res - HTTP response
+ * @param {express.Request} req - HTTP request
+ * @param {express.Response} res - HTTP response
  * @param {Function} next - Express callback
  */
 async function submit(req, res, next) {
+    if (!req.headers['content-type']?.startsWith('multipart/form-data')) {
+        res.status(400)
+            .set('content-type', 'text/xml')
+            .send(
+                /* xml */ `
+                <OpenRosaResponse xmlns="http://openrosa.org/http/response" items="0">
+                    <message nature="error">Required multipart POST field xml_submission_file missing.</message>
+                </OpenRosaResponse>
+                `.trim()
+            );
+
+        return;
+    }
+
     try {
         const paramName = req.app.get('query parameter to pass to submission');
         const paramValue = req.query[paramName];

--- a/test/server/submission-controller.spec.js
+++ b/test/server/submission-controller.spec.js
@@ -107,6 +107,23 @@ describe('Submissions', () => {
         });
     });
 
+    describe('submission content types', () => {
+        it('responds with 400 if content type is not specified', async () => {
+            await request(app)
+                .post(`/submission/${enketoId}`)
+                .send('foo=bar')
+                .expect(400);
+        });
+
+        it('responds with 400 if content type is not multipart/form-data', async () => {
+            await request(app)
+                .post(`/submission/${enketoId}`)
+                .set('Content-Type', 'application/json')
+                .send({ foo: 'bar' })
+                .expect(400);
+        });
+    });
+
     describe('using GET (existing submissions) for an existing/active Enketo IDs', () => {
         it('responds with 400 if no instanceID provided', (done) => {
             request(app).get(`/submission/${enketoId}`).expect(400, done);


### PR DESCRIPTION
This ensures that Enketo does not attempt to stream unexpected submission request bodies to an OpenRosa server.

#### I have verified this PR works with

-   [x] Online form submission
-   [x] Offline form submission
-   [x] Saving offline drafts
-   [x] Loading offline drafts
-   [x] Editing submissions
-   ~~[ ] Form preview~~ Not applicable

#### What else has been done to verify that this works as intended?

Manual and automated tests. I also verified that this is the same response an OpenRosa server would send for the same invalid payloads.

#### Why is this the best possible solution? Were any other approaches considered?

Non-multipart POST bodies are invalid for submissions.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This should have no user impact.

#### Do we need any specific form for testing your changes? If so, please attach one.

N/A