### PR TITLE
Fix: ensure `survey.media` is available in view mode

### DIFF
--- a/public/js/src/enketo-webform-view.js
+++ b/public/js/src/enketo-webform-view.js
@@ -102,6 +102,7 @@ function _init(formParts) {
             instanceStr: formParts.instance,
             external: formParts.externalData,
             instanceAttachments: formParts.instanceAttachments,
+            survey: formParts,
         })
         .then((form) => {
             formParts.languages = form.languages;


### PR DESCRIPTION
Fixes #481.

#### ~~I have verified this PR works with~~ None of the following are affected

-   Online form submission
-   Offline form submission
-   Saving offline drafts
-   Loading offline drafts
-   Editing submissions
-   Form preview
-   None of the above

#### What else has been done to verify that this works as intended?

Temporarily added a `/view/:enketo_id` route (because I don't know/can't remember how to access view mode with an encrypted id), loaded a form to reproduce the error, then manually validated that the change eliminates that error.

#### Why is this the best possible solution? Were any other approaches considered?

This property is now required in the call to controller-webform.js's `init`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No regression risk I can imagine, this fixes a regression in #459.

#### Do we need any specific form for testing your changes? If so, please attach one.

You'd need to know how to access a form in view mode.