### PR TITLE
Add number widgets by default

### DIFF
--- a/config/default-config.json
+++ b/config/default-config.json
@@ -62,7 +62,9 @@
         "text-max",
         "text-print",
         "rating",
-        "thousands-sep"
+        "thousands-sep",
+        "integer",
+        "decimal"
     ],
     "analytics": "google",
     "google": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3029,9 +3029,9 @@
             "dev": true
         },
         "enketo-core": {
-            "version": "6.1.4",
-            "resolved": "https://registry.npmjs.org/enketo-core/-/enketo-core-6.1.4.tgz",
-            "integrity": "sha512-6zGlR+AwK4nPsXLK9FU6RnTRTmhe07CksPnIVrvomulmg1t24Rq1vgmCWFP0Xf6vk1QlSdLVdd+FS/1/fOF/tQ==",
+            "version": "6.1.5",
+            "resolved": "https://registry.npmjs.org/enketo-core/-/enketo-core-6.1.5.tgz",
+            "integrity": "sha512-m2nxK5fdYCC8ZEcj4ws4pbyMnbtuRg20SMp1lE0ZRBIVkdu2O3Wp+WipVpp1b+r+8yOWv1qGuZVAAYeQQuGQUQ==",
             "requires": {
                 "bootstrap-datepicker": "1.9.x",
                 "html5sortable": "^0.13.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "csurf": "^1.11.0",
         "db.js": "^0.15.0",
         "debug": "^4.3.4",
-        "enketo-core": "^6.1.4",
+        "enketo-core": "^6.1.5",
         "enketo-transformer": "2.1.6",
         "evp_bytestokey": "^1.0.3",
         "express": "^4.18.1",

--- a/public/js/src/module/core-widgets.json
+++ b/public/js/src/module/core-widgets.json
@@ -28,5 +28,7 @@
     "url": "../../../node_modules/enketo-core/src/widget/url/url-widget",
     "text-max": "../../../node_modules/enketo-core/src/widget/text-max/text-max",
     "text-print": "../../../node_modules/enketo-core/src/widget/text-print/text-print",
-    "thousands-sep": "../../../node_modules/enketo-core/src/widget/thousands-sep/thousands-sep"
+    "thousands-sep": "../../../node_modules/enketo-core/src/widget/thousands-sep/thousands-sep",
+    "integer": "../../../node_modules/enketo-core/src/widget/number-input/decimal-input",
+    "decimal": "../../../node_modules/enketo-core/src/widget/number-input/integer-input"
 }


### PR DESCRIPTION
Folks who explicitly configure widgets in their config will have to be really careful to add these widgets.

#### I have verified this PR works with

-   [x] Online form submission
-   [x] Offline form submission
-   [x] Saving offline drafts
  - **NOTE** invalid values are cleared at this point which could lead to data loss. But I think it's ok to expect users to fix big red validation issues.
-   [x] Loading offline drafts
-   [x] Editing submissions
-   [x] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?
Tried various inputs in Firefox which was the source of issues previously.

#### Why is this the best possible solution? Were any other approaches considered?
It's applying the patch from the latest Core release.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There is some level of risk to numeric inputs which are pretty critical. ODK will do a QA pass at some point but others may want to verify this carefully as well.

As noted above, folks who explicitly configure widgets in their server config need to be really careful to add these. We'll add this to the release notes. Not adding these widgets will lead to data loss because users will inevitably put bad characters in numeric fields.

#### Do we need any specific form for testing your changes? If so, please attach one.
