### PR TITLE
Prepare 5.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,20 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 4.1.5 - 2022-11-28
+## 5.0.0 - 2022-12-06
+
+**BREAKING CHANGE**: widgets for integers and decimal inputs have been made into Enketo Core widgets. If you [specify widgets in your `config.json`](https://enketo.github.io/enketo-express/tutorial-10-configure.html#widgets), you **MUST** add `integer` and `decimal`.
+
+-   Dockerfile: use npm ci by @alxndrsn in (#471)
+-   Improve error messages for revoked forms/public access links (#487)
+-   Fix: validate number input values (enketo/enketo-core#926)
+-   Fix: allow arbitrary precision decimal values (enketo/enketo-core#932)
+-   Add number widgets by default (#493)
+
+## 4.1.5 - 2022-11-28 DO NOT USE: breaks numeric input
 
 -   Fix: use simpler selector for geopicker widgets (enketo/enketo-core#922)
 -   fix toggle or-appearance-compact with dynamic nested repeat group (enketo/enketo-core#914)
--   Fix: validate number input values (enketo/enketo-core#926)
 
 ## 4.1.4 - 2022-11-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 **BREAKING CHANGE**: widgets for integers and decimal inputs have been made into Enketo Core widgets. If you [specify widgets in your `config.json`](https://enketo.github.io/enketo-express/tutorial-10-configure.html#widgets), you **MUST** add `integer` and `decimal`.
 
--   Dockerfile: use npm ci by @alxndrsn in (#471)
+-   Dockerfile: use npm ci (#471)
 -   Improve error messages for revoked forms/public access links (#487)
 -   Fix: validate number input values (enketo/enketo-core#926)
 -   Fix: allow arbitrary precision decimal values (enketo/enketo-core#932)

--- a/docs/app_controllers_transformation-controller.js.html
+++ b/docs/app_controllers_transformation-controller.js.html
@@ -53,6 +53,7 @@
 
 const transformer = require('enketo-transformer');
 const communicator = require('../lib/communicator');
+const { TranslatedError } = require('../lib/custom-error');
 const surveyModel = require('../models/survey-model');
 const cacheModel = require('../models/cache-model');
 const account = require('../models/account-model');
@@ -96,17 +97,29 @@ router
  * @param {Function} next - Express callback
  */
 async function getSurveyParts(req, res, next) {
+    /** @type {string | null} */
+    let formId = null;
+
+    /** @type {string | null} */
+    let formFileName = null;
+
     try {
         let survey = await _getSurveyParams(req);
 
         // A request with "xformUrl" body parameter was used (unlaunched form)
         if (survey.info != null) {
+            formFileName = survey.info.downloadUrl.replace(
+                /.*\/([^/]+)$/,
+                '$1'
+            );
             survey = await _getFormDirectly(survey);
 
             _respond(res, survey);
 
             return;
         }
+
+        formId = survey.openRosaId;
 
         const authenticated = await _authenticate(survey);
         const cached = await _getFormFromCache(authenticated);
@@ -127,7 +140,22 @@ async function getSurveyParts(req, res, next) {
             media,
         });
     } catch (error) {
-        next(error);
+        if (error.status === 403) {
+            const notFoundError =
+                formId == null
+                    ? new TranslatedError('error.notfounddirectformurl', {
+                          formFileName,
+                      })
+                    : new TranslatedError('error.notfoundinformlist', {
+                          formId,
+                      });
+
+            notFoundError.status = 404;
+
+            next(notFoundError);
+        } else {
+            next(error);
+        }
     }
 }
 

--- a/docs/module-transformation-controller.html
+++ b/docs/module-transformation-controller.html
@@ -98,7 +98,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line189">line 189</a>
+        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line217">line 217</a>
     </li></ul></dd>
     
 
@@ -252,7 +252,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line123">line 123</a>
+        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line151">line 151</a>
     </li></ul></dd>
     
 
@@ -406,7 +406,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line200">line 200</a>
+        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line228">line 228</a>
     </li></ul></dd>
     
 
@@ -560,7 +560,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line246">line 246</a>
+        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line274">line 274</a>
     </li></ul></dd>
     
 
@@ -716,7 +716,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line114">line 114</a>
+        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line142">line 142</a>
     </li></ul></dd>
     
 
@@ -870,7 +870,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line132">line 132</a>
+        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line160">line 160</a>
     </li></ul></dd>
     
 
@@ -1024,7 +1024,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line282">line 282</a>
+        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line310">line 310</a>
     </li></ul></dd>
     
 
@@ -1178,7 +1178,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line222">line 222</a>
+        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line250">line 250</a>
     </li></ul></dd>
     
 
@@ -1333,7 +1333,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line269">line 269</a>
+        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line297">line 297</a>
     </li></ul></dd>
     
 
@@ -1510,7 +1510,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line143">line 143</a>
+        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line171">line 171</a>
     </li></ul></dd>
     
 
@@ -1668,7 +1668,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line92">line 92</a>
+        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line120">line 120</a>
     </li></ul></dd>
     
 
@@ -1850,7 +1850,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line49">line 49</a>
+        <a href="app_controllers_transformation-controller.js.html">app/controllers/transformation-controller.js</a>, <a href="app_controllers_transformation-controller.js.html#line50">line 50</a>
     </li></ul></dd>
     
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "enketo-express",
-    "version": "4.1.5",
+    "version": "5.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2849,9 +2849,9 @@
             "integrity": "sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg=="
         },
         "dezalgo": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-            "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+            "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
             "dev": true,
             "requires": {
                 "asap": "^2.0.0",
@@ -4709,23 +4709,15 @@
             "integrity": "sha512-WGThlbRC1ELTwfR4HGLFnUBU3yzaOmiZ1ZbPgic3XsS3nGTzZdrxOLwsP4kz6QBdy1KAwvoLwN9TJk08mfqxxA=="
         },
         "formidable": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
-            "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+            "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
             "dev": true,
             "requires": {
-                "dezalgo": "1.0.3",
-                "hexoid": "1.0.0",
-                "once": "1.4.0",
-                "qs": "6.9.3"
-            },
-            "dependencies": {
-                "qs": {
-                    "version": "6.9.3",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-                    "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==",
-                    "dev": true
-                }
+                "dezalgo": "^1.0.4",
+                "hexoid": "^1.0.0",
+                "once": "^1.4.0",
+                "qs": "^6.11.0"
             }
         },
         "forwarded": {
@@ -9511,10 +9503,13 @@
             "dev": true
         },
         "qs": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-            "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-            "dev": true
+            "version": "6.11.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+            "dev": true,
+            "requires": {
+                "side-channel": "^1.0.4"
+            }
         },
         "quick-lru": {
             "version": "4.0.1",
@@ -10582,9 +10577,9 @@
             "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
         },
         "superagent": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.3.tgz",
-            "integrity": "sha512-WA6et4nAvgBCS73lJvv1D0ssI5uk5Gh+TGN/kNe+B608EtcVs/yzfl+OLXTzDs7tOBDIpvgh/WUs1K2OK1zTeQ==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.5.tgz",
+            "integrity": "sha512-HQYyGuDRFGmZ6GNC4hq2f37KnsY9Lr0/R1marNZTgMweVDQLTLJJ6DGQ9Tj/xVVs5HEnop9EMmTbywb5P30aqw==",
             "dev": true,
             "requires": {
                 "component-emitter": "^1.3.0",
@@ -10617,15 +10612,6 @@
                     "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
                     "dev": true
                 },
-                "qs": {
-                    "version": "6.10.3",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-                    "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
-                    "dev": true,
-                    "requires": {
-                        "side-channel": "^1.0.4"
-                    }
-                },
                 "readable-stream": {
                     "version": "3.6.0",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -10638,9 +10624,9 @@
                     }
                 },
                 "semver": {
-                    "version": "7.3.7",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-                    "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+                    "version": "7.3.8",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "enketo-express",
     "description": "Webforms evolved.",
     "homepage": "https://enketo.org",
-    "version": "4.1.5",
+    "version": "5.0.0",
     "main": "./app.js",
     "engines": {
         "node": ">=14.8.0 <17",


### PR DESCRIPTION
Prepares release 5.0.0.

This is not a great sequence of releases. I want to provide a little bit of context for anyone watching and/or myself later.

It seemed simple and sensible to use the Enketo Core widgets framework to improve numeric inputs (https://github.com/enketo/enketo-core/pull/926). For some reason I thought everything worked in Express when I updated Core in https://github.com/enketo/enketo-express/releases/tag/4.1.5. 

I quickly realized that Core widgets are not included by default by Express which to me is surprising. I can see how someone might want to map to custom widgets, though.

That left us with Core released with new integer and decimal widgets and EE not using them at all. I wasn't able to work through what to do immediately so I marked the releases as unusable until I could come back.

In the process of including the new widgets at https://github.com/enketo/enketo-express/pull/493, I went back to the docs at https://enketo.github.io/enketo-express/tutorial-10-configure.html#widgets and realized that the widget list is not additive but instead replaces the default if specified.

This release has the potential of breaking deployments that specify custom widgets. We're hoping the major version change mitigates that and we'll send some direct messages as well. We will also hopefully revise the widget configuration soon: https://github.com/enketo/enketo-express/issues/495