### PR TITLE
Fix: loading offline-enabled.png regardless of base path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ public/css/*.css
 **/build/*
 translation_old.json
 app/views/styles/component/_widgets.scss
-app/views/styles/component/_system_variables.scss
 config/config.json
 enketo-main.rdb
 setup/docker/secrets/*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,11 +56,7 @@ module.exports = (grunt) => {
         },
         watch: {
             sass: {
-                files: [
-                    'app/views/styles/**/*.scss',
-                    'widget/**/*.scss',
-                    '!app/views/styles/component/_system_variables.scss',
-                ],
+                files: ['app/views/styles/**/*.scss', 'widget/**/*.scss'],
                 tasks: ['shell:clean-css', 'sass'],
                 options: {
                     spawn: false,
@@ -256,21 +252,6 @@ module.exports = (grunt) => {
         );
     });
 
-    grunt.registerTask(
-        'system-sass-variables',
-        'Creating _system_variables.scss',
-        () => {
-            const SYSTEM_SASS_VARIABLES_PATH =
-                'app/views/styles/component/_system_variables.scss';
-            const config = require('./app/models/config-model');
-            grunt.file.write(
-                SYSTEM_SASS_VARIABLES_PATH,
-                `$base-path: "${config.server['base path']}";`
-            );
-            grunt.log.writeln(`File ${SYSTEM_SASS_VARIABLES_PATH} created`);
-        }
-    );
-
     grunt.registerTask('widgets', 'generate widget reference files', () => {
         const WIDGETS_JS_LOC = 'public/js/build/';
         const WIDGETS_JS = `${WIDGETS_JS_LOC}widgets.js`;
@@ -317,7 +298,13 @@ module.exports = (grunt) => {
         grunt.log.writeln(`File ${WIDGETS_SASS} created`);
     });
 
-    grunt.registerTask('default', ['clean', 'locales', 'widgets', 'css', 'js']);
+    grunt.registerTask('default', [
+        'clean',
+        'locales',
+        'widgets',
+        'sass',
+        'js',
+    ]);
     grunt.registerTask('clean', [
         'shell:clean-js',
         'shell:clean-css',
@@ -325,23 +312,22 @@ module.exports = (grunt) => {
     ]);
     grunt.registerTask('locales', ['i18next']);
     grunt.registerTask('js', ['widgets', 'shell:build']);
-    grunt.registerTask('css', ['system-sass-variables:create', 'sass']);
     grunt.registerTask('test', [
         'env:test',
         'js',
-        'css',
+        'sass',
         'shell:nyc',
         'karma:headless',
         'eslint:check',
     ]);
-    grunt.registerTask('test-browser', ['env:test', 'css', 'karma:browsers']);
+    grunt.registerTask('test-browser', ['env:test', 'sass', 'karma:browsers']);
     grunt.registerTask('test-watch-client', ['env:test', 'karma:watch']);
     grunt.registerTask('test-watch-server', ['env:test', 'watch:mochaTest']);
     grunt.registerTask('develop', [
         'env:develop',
         'i18next',
         'js',
-        'css',
+        'sass',
         'concurrent:develop',
     ]);
     grunt.registerTask('test-and-build', [

--- a/app/views/styles/component/_form_header.scss
+++ b/app/views/styles/component/_form_header.scss
@@ -129,7 +129,7 @@ $offline-color: #d15200;
         width: 34px;
         height: 34px;
         background-color: $offline-color;
-        background-image: url($base-path + '/x/images/offline-enabled.png');
+        background-image: url('../images/offline-enabled.png');
         background-repeat: no-repeat;
         opacity: 1;
 

--- a/app/views/styles/component/_variables.scss
+++ b/app/views/styles/component/_variables.scss
@@ -1,4 +1,1 @@
-@import 'system_variables';
-
-$base-path: '' !default;
 $fa-font-path: '../fonts';


### PR DESCRIPTION
Also eliminates the system-sass-variables build step

Closes https://github.com/getodk/central/issues/370

#### I have verified this PR works with

-   [x] Offline form submission
-   No other modes are applicable

#### What else has been done to verify that this works as intended?

Checked that the image loads as expected with the default Central base path, as well as a modified base path of `/enk/eto` to verify it works at arbitrary path depth.

#### Why is this the best possible solution? Were any other approaches considered?

Less code and fewer build steps to accomplish the same thing. This specifically affects Docker, which don't (and shouldn't) have a local config when we publish the image. An alternative approach would be to use the standard [`base`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) element, but that would affect quite a few other relative URLs already in use. I'd like to make that change, but felt it's better to do in a future change not specifically fixing this issue.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The only risk I could imagine is if users are using a custom `base` element, but if so they are probably making other customizations, and they'd almost certainly notice the build change.

#### Do we need any specific form for testing your changes? If so, please attach one.

Load any form in offline-capable mode. In a local dev environment, you'll likely also need to unregister any current Service Worker and clear Cache Storage (or private mode in supported browsers).