### PR TITLE
Fix: works around issue with canvas not printing in puppeteer's PDF g…

### DIFF
--- a/app/lib/pdf.js
+++ b/app/lib/pdf.js
@@ -71,6 +71,7 @@ async function get(url, options = {}) {
          * (though not WebGL-related as some of the commenters suggest)
          */
         await page.evaluate(() => {
+            /* eslint-env browser */
             function canvasToImage(element) {
                 const image = document.createElement('img');
                 image.src = element.toDataURL();

--- a/app/lib/pdf.js
+++ b/app/lib/pdf.js
@@ -64,6 +64,33 @@ async function get(url, options = {}) {
                 throw e;
             });
 
+        /*
+         * This works around an issue with puppeteer not printing canvas
+         * images that were loaded from a file.
+         * It is likely this issue: https://bugs.chromium.org/p/chromium/issues/detail?id=809065
+         * (though not WebGL-related as some of the commenters suggest)
+         */
+        await page.evaluate(() => {
+            function canvasToImage(element) {
+                const image = document.createElement('img');
+                image.src = element.toDataURL();
+
+                ['width', 'height', 'position', 'left', 'top'].forEach(
+                    (property) =>
+                        (image.style[property] = element.style[property])
+                );
+                // overriding a general image style
+                image.style['max-width'] = '100%';
+                image.className = element.className;
+
+                element.parentNode &&
+                    element.parentNode.insertBefore(image, element);
+                element.parentNode && element.parentNode.removeChild(element);
+            }
+
+            document.querySelectorAll('canvas').forEach(canvasToImage);
+        });
+
         pdf = await page.pdf({
             landscape: options.landscape,
             format: options.format,


### PR DESCRIPTION
…eneration, closes #512

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [x] None of the above

#### What else has been done to verify that this works as intended?

The code is only used for PDF generation. Therefore, I've only tested the PDF API endpoints. 

#### Why is this the best possible solution? Were any other approaches considered?

I concluded that the issue is a bug in puppeteer in the printToPDF implementation of a '2d' canvas. Therefore, it seemed best to work around it. In the PDF view, there is no need for a real canvas, so converting canvases to images seemed an acceptable solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Regression risks are styling changes in the drawing widget or general images that unintentionally affect drawings in the PDF view.

#### Do we need any specific form for testing your changes? 

See the linked issue for API calls to reproduce the issue and test the fix.
