### PR TITLE
fix: load external data when served with 'application/geo+json' Content-Type header

### DIFF
--- a/public/js/src/module/connection.js
+++ b/public/js/src/module/connection.js
@@ -632,11 +632,11 @@ function getDataFile(url, languageMap) {
                 url.endsWith('.geojson')
             ) {
                 contentType = 'application/geo+json';
-
-                return response.json();
             }
 
-            return response.text();
+            return contentType === 'application/geo+json'
+                ? response.json()
+                : response.text();
         })
         .then((responseData) => {
             let result;


### PR DESCRIPTION
Fixes: https://github.com/enketo/enketo-express/issues/518

#### I have verified this PR works with

-   [x] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [x] Form preview
-   [ ] None of the above
