### PR TITLE
fixed: The app UI strings in newly created repeats are not translated…

### DIFF
--- a/public/js/src/module/controller-webform.js
+++ b/public/js/src/module/controller-webform.js
@@ -873,6 +873,12 @@ function _setEventHandlers(survey) {
             );
         });
     }
+    // This actually belongs in gui.js but that module doesn't have access to the form object.
+    // This handler is also used in forms that have no translation (and thus no defined language).
+    // See scenario X in https://docs.google.com/spreadsheets/d/1CigMLAQewcXi-OJJHi_JQQ-fJXOam99livM0oYrtbkk/edit#gid=1504432290
+    document.addEventListener(events.AddRepeat().type, (event) => {
+        localize(event.target, form.currentLanguage);
+    });
 
     if (settings.offline) {
         document.addEventListener(


### PR DESCRIPTION
… to the current language, closes #526

Closes #526

#### I have verified this PR works with

* translated forms
* non-translated forms

#### What else has been done to verify that this works as intended?

Nothing. I'm sorry to have not tried to add a test. 

#### Why is this the best possible solution? Were any other approaches considered?

Enketo deals with XForms strings in Enketo Core and UI strings in Enketo Express. Only an "add-repeat" event handler was considered as a solution. It was placed underneath a similar handler that handles user language switching.

However, I realized afterwards that an alternative solution would be to localize the repeat templates (`form.repeats.templates`) both upon load and when the user switches a language. That way new repeats are always in the current language at the time of creation without manipulation.

I don't have a preference for one of these at the moment. I'd be happy to change this PR to use the latter solution if preferred.

#### How does this change affect users? 

It will make them happier when using forms that have repeats, especially users that do not speak English.

#### Do we need any specific form for testing your changes? If so, please attach one.

Please see 2 forms added to the issue #526.
