### PR TITLE
Retry failed upload attempts on an exponential backoff (uploadQueue)

### DIFF
--- a/public/js/src/module/exponential-backoff.js
+++ b/public/js/src/module/exponential-backoff.js
@@ -12,8 +12,8 @@ const state = {
 export function backoff(uploadQueue) {
     // Exponentially increases to 5 minutes then relies on existing interval
     if (state.n < 9) {
-        const offset = Math.min(2 ** state.n - 1, 5 * 60) * 1000;
-        console.log(`Trying to upload again... Next attempt in: ${offset}`);
+        const offset = Math.min(2 ** state.n + 4, 5 * 60) * 1000;
+        console.log(`Trying to upload again... Next attempt in: ${offset / 1000} seconds`);
         state.n += 1;
         state.tid = setTimeout(uploadQueue, offset);
     } else {

--- a/public/js/src/module/exponential-backoff.js
+++ b/public/js/src/module/exponential-backoff.js
@@ -1,0 +1,26 @@
+import records from './records-queue';
+
+const state = {
+    n: 0, // iteration
+    tid: null, // currently running timeout ID
+};
+
+export function backoff() {
+    if (state.n < 9) { // will result in > 5 minutes
+        let offset = Math.min(2 ** state.n - 1, 300) * 1000;
+        console.log(`Trying to upload again... Next attempt in: ${offset}`);
+        state.n = state.n + 1;
+        state.tid = setTimeout(records.uploadQueue, offset);
+    }
+}
+
+export function cancelBackoff() {
+    if (state.tid) {
+        state.n = 0;
+        clearTimeout(state.tid);
+    }
+}
+
+function startBackoff() {
+    state.tid = setTimeout(backoff, 0);
+};

--- a/public/js/src/module/records-queue.js
+++ b/public/js/src/module/records-queue.js
@@ -189,7 +189,7 @@ function _setUploadIntervals() {
     // one quick upload attempt immediately after page load
     setTimeout(() => {
         uploadQueue();
-    }, 0);
+    }, 5 * 1000); // 5 second buffer
     // interval to upload queued records
     setInterval(() => {
         uploadQueue();

--- a/public/js/src/module/records-queue.js
+++ b/public/js/src/module/records-queue.js
@@ -13,6 +13,7 @@ import exporter from './exporter';
 import { t } from './translator';
 import formCache from './form-cache';
 import { setLastSavedRecord } from './last-saved';
+import { backoff, cancelBackoff } from './exponential-backoff';
 
 let $exportButton;
 let $uploadButton;
@@ -279,6 +280,7 @@ function uploadQueue(byUser = false) {
                                     );
                             })
                             .catch((result) => {
+                                console.log('catch me');
                                 // catch 401 responses (1 of them)
                                 if (result.status === 401) {
                                     authRequired = true;
@@ -308,6 +310,9 @@ function uploadQueue(byUser = false) {
                 document.dispatchEvent(
                     events.QueueSubmissionSuccess(successes)
                 );
+                cancelBackoff();
+            } else {
+                backoff(); 
             }
 
             // update the list by properly removing obsolete records, reactivating button(s)

--- a/public/js/src/module/records-queue.js
+++ b/public/js/src/module/records-queue.js
@@ -186,10 +186,10 @@ function setActive(instanceId) {
  * Sets the interval to upload queued records
  */
 function _setUploadIntervals() {
-    // one quick upload attempt soon after page load
+    // one quick upload attempt immediately after page load
     setTimeout(() => {
         uploadQueue();
-    }, 30 * 1000);
+    }, 0);
     // interval to upload queued records
     setInterval(() => {
         uploadQueue();
@@ -280,7 +280,6 @@ function uploadQueue(byUser = false) {
                                     );
                             })
                             .catch((result) => {
-                                console.log('catch me');
                                 // catch 401 responses (1 of them)
                                 if (result.status === 401) {
                                     authRequired = true;
@@ -310,9 +309,12 @@ function uploadQueue(byUser = false) {
                 document.dispatchEvent(
                     events.QueueSubmissionSuccess(successes)
                 );
+
+                // Cancel current backoff if upload is successful
                 cancelBackoff();
             } else {
-                backoff(); 
+                // Start/continue upload retries with exponential backoff if upload is not successful
+                backoff(uploadQueue);
             }
 
             // update the list by properly removing obsolete records, reactivating button(s)


### PR DESCRIPTION
Closes #515

#### I have verified this PR works with

-   [x] Online form submission
-   [x] Offline form submission
-   [x] Saving offline drafts
-   [x] Loading offline drafts
-   [ ] Editing submissions 
  - for editing submissions, `_uploadBatch` has no attempts at automatic upload retries
-   [x] Form preview

#### What else has been done to verify that this works as intended?
We attempted submissions with browser in offline mode. We waited for notifications of failed upload attempts then stopped offline mode for browser. The backoff successfully uploaded the submission after the stated delay.
#### Why is this the best possible solution? Were any other approaches considered?
We moved most of this logic to a separate file to compartmentalize it. Although it looks like a generic function, it's really only written to support being called by the `_uploadQueue` function. The reason `_uploadQueue` is not hard coded inside `backoff` is to avoid a circular dependency (appease @eslint/no-cycle).
#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The intended behavior is to allow for sooner upload intervals (after a failure) and backoff reasonably up to the original upload interval (5 minutes). We tried to limit regression by leaving the original 5 minute upload timer as is.
#### Do we need any specific form for testing your changes? If so, please attach one.
Works with any form.