### PR TITLE
Use pm2-runtime on docker/start.sh

### DIFF
--- a/setup/docker/start.sh
+++ b/setup/docker/start.sh
@@ -8,6 +8,6 @@ cd ${ENKETO_SRC_DIR}/
 # Create a config. file if necessary.
 python setup/docker/create_config.py
 
-# Run Enketo via PM2 (without daemonizing, so logs are exposed
-#   e.g. via `docker logs enketoexpress_enketo_1`).
-exec pm2 start --no-daemon app.js -n enketo
+# Run Enketo via PM2 Runtime (To support sigterm handling and
+# logs are exposed e.g. via `docker logs enketoexpress_enketo_1`).
+exec pm2-runtime app.js -n enketo


### PR DESCRIPTION
Closes #531

#### I have verified this PR works with

-   [x] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?

Start via Docker Compose (I choose to mount the start.sh file inside the Docker image `kobotoolbox/enketo-express-extra-widgets` for convenience. Without this patch, the following scenarios are not handled properly and only the 10 second docker termination timeout will stop the container.

- (exec in docker container) kill 1
- Terminate docker compose via Ctrl-C interrupt
- Terminate docker container via `docker stop`

With this patch, the container exists almost immediately (under 1 second).

Additionally, I tested in a Kubernetes cluster by overriding the command with pm2-runtime. When running a rolling deployment, I observed greatly faster pod termination with pm2-runtime.

#### Why is this the best possible solution? Were any other approaches considered?

PM2 [recommends](https://pm2.keymetrics.io/docs/usage/docker-pm2-nodejs/) PM2 Runtime for Docker environments. We also considered only documenting the problem and writing a custom handling of SIGTERM.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I would expect only Docker users to be affected, given that the file is in a docker directory. Docker users should expect faster container termination. It is possible that pm2-runtime differs in other ways. I am not sure exactly what. However it is the recommended approach.