### PR TITLE
Feature/exponential backoff refinements

### DIFF
--- a/public/js/src/module/controller-webform.js
+++ b/public/js/src/module/controller-webform.js
@@ -591,23 +591,26 @@ function _saveRecord(survey, draft, recordName, confirmed) {
             _resetForm(survey, { isOffline: true });
 
             if (draft) {
+                return true;
+            }
+
+            return records.uploadQueue({ isUserTriggered: !draft });
+        })
+        .then((success) => {
+            if (success && draft) {
                 gui.alert(
                     t('alert.recordsavesuccess.draftmsg'),
                     t('alert.savedraftinfo.heading'),
                     'info',
                     5
                 );
-            } else {
+            } else if (!success && !draft) {
                 gui.alert(
                     `${t('record-list.msg2')}`,
                     t('alert.recordsavesuccess.finalmsg'),
                     'info',
                     10
                 );
-                // The timeout simply avoids showing two messages at the same time:
-                // 1. "added to queue"
-                // 2. "successfully submitted"
-                setTimeout(records.uploadQueue, 10 * 1000);
             }
         })
         .catch((error) => {
@@ -770,7 +773,7 @@ function _setEventHandlers(survey) {
     });
 
     $('.record-list__button-bar__button.upload').on('click', () => {
-        records.uploadQueue(true);
+        records.uploadQueue({ isUserTriggered: true });
     });
 
     $('.record-list__button-bar__button.export').on('click', () => {

--- a/public/js/src/module/exponential-backoff.js
+++ b/public/js/src/module/exponential-backoff.js
@@ -1,0 +1,26 @@
+import records from './records-queue';
+
+const state = {
+    n: 0, // iteration
+    tid: null, // currently running timeout ID
+};
+
+export function backoff() {
+    if (state.n < 9) { // will result in > 5 minutes
+        let offset = Math.min(2 ** state.n - 1, 300) * 1000;
+        console.log(`Trying to upload again... Next attempt in: ${offset}`);
+        state.n = state.n + 1;
+        state.tid = setTimeout(records.uploadQueue, offset);
+    }
+}
+
+export function cancelBackoff() {
+    if (state.tid) {
+        state.n = 0;
+        clearTimeout(state.tid);
+    }
+}
+
+function startBackoff() {
+    state.tid = setTimeout(backoff, 0);
+};

--- a/public/js/src/module/records-queue.js
+++ b/public/js/src/module/records-queue.js
@@ -308,19 +308,16 @@ const uploadQueue = async (
     uploadOngoing = false;
     $uploadButton.btnBusyState(false);
 
-    let result = false;
+    const success = !authRequired && successes.length === records.length;
 
     if (authRequired) {
         gui.confirmLogin();
-    } else if (successes.length > 0) {
-        // TODO: shouldn't this check that *all* uploads were successful?
+    } else if (success) {
         // let gui send a feedback message
         document.dispatchEvent(events.QueueSubmissionSuccess(successes));
 
         // Cancel current backoff if upload is successful
         cancelBackoff();
-
-        result = true;
     } else {
         // Start/continue upload retries with exponential backoff if upload is not successful
         uploadOngoing = false;
@@ -331,7 +328,7 @@ const uploadQueue = async (
     // update the list by properly removing obsolete records, reactivating button(s)
     _updateRecordList();
 
-    return result;
+    return success;
 };
 
 /**

--- a/public/js/src/module/records-queue.js
+++ b/public/js/src/module/records-queue.js
@@ -13,6 +13,7 @@ import exporter from './exporter';
 import { t } from './translator';
 import formCache from './form-cache';
 import { setLastSavedRecord } from './last-saved';
+import { backoff, cancelBackoff } from './exponential-backoff';
 
 let $exportButton;
 let $uploadButton;
@@ -279,6 +280,7 @@ function uploadQueue(byUser = false) {
                                     );
                             })
                             .catch((result) => {
+                                console.log('catch me');
                                 // catch 401 responses (1 of them)
                                 if (result.status === 401) {
                                     authRequired = true;
@@ -308,6 +310,9 @@ function uploadQueue(byUser = false) {
                 document.dispatchEvent(
                     events.QueueSubmissionSuccess(successes)
                 );
+                cancelBackoff();
+            } else {
+                backoff(); 
             }
 
             // update the list by properly removing obsolete records, reactivating button(s)

--- a/public/js/src/module/records-queue.js
+++ b/public/js/src/module/records-queue.js
@@ -186,10 +186,10 @@ function setActive(instanceId) {
  * Sets the interval to upload queued records
  */
 function _setUploadIntervals() {
-    // one quick upload attempt soon after page load
+    // one quick upload attempt immediately after page load
     setTimeout(() => {
         uploadQueue();
-    }, 30 * 1000);
+    }, 0);
     // interval to upload queued records
     setInterval(() => {
         uploadQueue();
@@ -280,7 +280,6 @@ function uploadQueue(byUser = false) {
                                     );
                             })
                             .catch((result) => {
-                                console.log('catch me');
                                 // catch 401 responses (1 of them)
                                 if (result.status === 401) {
                                     authRequired = true;
@@ -310,9 +309,12 @@ function uploadQueue(byUser = false) {
                 document.dispatchEvent(
                     events.QueueSubmissionSuccess(successes)
                 );
+
+                // Cancel current backoff if upload is successful
                 cancelBackoff();
             } else {
-                backoff(); 
+                // Start/continue upload retries with exponential backoff if upload is not successful
+                backoff(uploadQueue);
             }
 
             // update the list by properly removing obsolete records, reactivating button(s)


### PR DESCRIPTION
Closes #515. Expands on changes in #532. Thanks @duvld for getting the ball rolling! I'd welcome any feedback you have.

#### What's changed

Aside from the specific behavior detailed in #515/#532, I'll call out details from the commit notes in 2764666.

- Adds several tests, mostly around behavior of `uploadQueue` (records-queue.js).

- Converts `uploadQueue` to `async`/`await`. As usual, this is part of an ongoing gradual effort, which I've generally prioritized when it aids understanding of more complex affected code. I hope it's clear what's unchanged, but I'm happy to identify and describe the substantive changes if needed.

- **All** retry and polling logic is now handled in exponential-backoff.js. Notably, there is no longer a global polling interval. Instead:

    0. After initialization, if any submission records are queued, upload is attempted immediately

    1. On **any** upload attempt, if the user is offline (as determined by `connection.getOnlineStatus`) or if a non-auth response error is encountered, retries are initiated.

    2. Each subsequent failure backs off until the global maximum (5 minutes).

    3. Each subsequent failure after that is explicitly retried every 5 minutes (replacing the original global persistent polling with `setInterval`). This ensures that the final backoff occurs _after_ the previous one. It also consolidates related logic, rather than implicitly coupling it across modules.

- The 10 second delay on user-initiated submission has been eliminated. The comment explaining that behavior was about preventing two concurrent messages being displayed to the user:

    1. The temporary modal dialog describing queueing/polling behavior.

    2. The non-modal (at least on desktop) banner notifying upload success.

    This change addresses that by attempting upload, notifying on success and only showing the queue/poll dialog on failure. Unfortunately this required changes in controller-webform.js which are as yet untested, but I tried to keep those changes minimal.

- Previously, `uploadQueue` would treat a single successful upload as complete success. It now treats any partial failure as failure, and continues to retry. This was discussed with @lognaturel and we agreed the change makes sense. It's possible to view this as a "breaking change", but I think it's better framed as a bug fix (caveat: discussion of messaging in the section below).

#### Things we [might] want to address

- While the change to treat partial failure as failure makes more sense, as it will continue retrying as expected, it does raise the question of how we should message partial failure to the user.

- The language in the queue/poll dialog almost definitely needs to be reworded.

- Given the exponential backoff implementation is currently _not_ generic, does it make sense for it to be in a separate module?

- Is it worth making it more general now? We'd likely be able/want to reuse it for other retry and polling logic, e.g. updating the service worker and offline app resource cache.

- Most of the early exit conditions in `uploadQueue` may not be appropriate or ideal to keep in place. It would simplify a lot of things to remove them, and I can't see any harm in doing so. I think the likely exception would be `uploadOngoing`, but even so it's problematic (probably moreso with the current state of this change, as the global/persistent retry polling is eliminated).

- It's weird that there's still some messaging/UI responsibility in `uploadQueue`. I left it as-is to avoid more substantial changes to controller-webform.js (which is where I think it would likely go).

#### I have verified this PR works with

-   [ ] Online form submission
-   [x] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?

Quite a bit of manual testing, expanded automated testing around ~everything (excepting stuff in controller-webform.js).

#### Why is this the best possible solution? Were any other approaches considered?

Smaller changes to #532 were possible, but I had some concerns with consistency of behavior and coupling between records-queue.js and exponential-backoff.js.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The biggest concern I'd call out is that this generally increases network activity. For that reason, I'd like to consider making specifically the backoff behavior configurable after all.

#### Do we need any specific form for testing your changes? If so, please attach one.

Works with any form, in offline-capable mode.