### PR TITLE
feat(redis): enable TLS and prefix parameters

### DIFF
--- a/app/lib/db.js
+++ b/app/lib/db.js
@@ -1,11 +1,16 @@
 const redis = require('redis');
 const config = require('../models/config-model').server;
 
+// uncomment to enable redis debugging
+// redis.debug_mode = true;
+
 const mainClient = redis.createClient(
     config.redis.main.port,
     config.redis.main.host,
     {
         auth_pass: config.redis.main.password,
+        prefix: config.redis.main.prefix,
+        tls: config.redis.main.tls,
     }
 );
 
@@ -14,6 +19,8 @@ const cacheClient = redis.createClient(
     config.redis.cache.host,
     {
         auth_pass: config.redis.cache.password,
+        prefix: config.redis.cache.prefix,
+        tls: config.redis.cache.tls,
     }
 );
 

--- a/config/default-config.json
+++ b/config/default-config.json
@@ -86,7 +86,9 @@
     "maps": [
         {
             "name": "streets",
-            "tiles": ["https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"],
+            "tiles": [
+                "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            ],
             "attribution": "© <a href=\"http://openstreetmap.org\">OpenStreetMap</a> | <a href=\"www.openstreetmap.org/copyright\">Terms</a>"
         }
     ],
@@ -95,12 +97,16 @@
         "main": {
             "host": "127.0.0.1",
             "port": "6379",
-            "password": null
+            "password": null,
+            "tls": null,
+            "prefix": null
         },
         "cache": {
             "host": "127.0.0.1",
             "port": "6380",
-            "password": null
+            "password": null,
+            "tls": null,
+            "prefix": null
         }
     },
     "logo": {

--- a/tutorials/10-configure.md
+++ b/tutorials/10-configure.md
@@ -183,7 +183,7 @@ Specifies the name of a query parameter that will be copied from an Enketo URL t
 -   cache -> password: Password of the cache redis database instance. Usually `null`.
 -   cache -> tls: Object parameters for TLS options. Set this to empty `{}` to enable TLS. Optionally provide TLS options as listed on the [Node.js TLS docs](https://nodejs.org/api/tls.html#tls_tls_connect_port_host_options_callback)
 -   cache -> prefix: If redis is configured in cluster mode, you may configure a prefix for your client. This is configured via prefix, for example: `prefix: '{enk_cache}'`. You will know this is necessary if you receive this error: `CROSSSLOT Keys in request don't hash to the same slot`. Prefix must be wrapped in curly braces.
--
+
 #### logo
 
 -   source: The logo at the top of each form. Can be a Data URI or just a path to a image file you place in public/images, e.g. `"/images/mylogo.png"`.

--- a/tutorials/10-configure.md
+++ b/tutorials/10-configure.md
@@ -176,10 +176,14 @@ Specifies the name of a query parameter that will be copied from an Enketo URL t
 -   main -> host: The IP address of the main redis database instance. If installed on the same server as Enketo Express, the value is `"127.0.0.1"`
 -   **main -> port: The port of the main redis database instance. This is the important persistent database that contains the unique IDs for each forms. The default value is `"6379"`**
 -   main -> password: Password of the main redis database instance. Usually `null`.
+-   main -> tls: Object parameters for TLS options. Set this to empty `{}` to enable TLS. Optionally provide TLS options as listed on the [Node.js TLS docs](https://nodejs.org/api/tls.html#tls_tls_connect_port_host_options_callback)
+-   main -> prefix: If redis is configured in cluster mode, you may configure a prefix for your client. This is configured via prefix, for example: `prefix: '{enk_main}'`. You will know this is necessary if you receive this error: `CROSSSLOT Keys in request don't hash to the same slot`. Prefix must be wrapped in curly braces.
 -   cache -> host: The IP address of the cache redis database instance. If installed on the same server as Enketo Express, the value is `"127.0.0.1"`
 -   **cache -> port: The port of the cache redis database instance. This is the non-persistent database that is just used for caching to greatly improve performance. When testing or developing you could use one redis instance for both 'main' and 'cache' (e.g. both `"6379"`") but do not do this in production.**
 -   cache -> password: Password of the cache redis database instance. Usually `null`.
-
+-   cache -> tls: Object parameters for TLS options. Set this to empty `{}` to enable TLS. Optionally provide TLS options as listed on the [Node.js TLS docs](https://nodejs.org/api/tls.html#tls_tls_connect_port_host_options_callback)
+-   cache -> prefix: If redis is configured in cluster mode, you may configure a prefix for your client. This is configured via prefix, for example: `prefix: '{enk_cache}'`. You will know this is necessary if you receive this error: `CROSSSLOT Keys in request don't hash to the same slot`. Prefix must be wrapped in curly braces.
+-
 #### logo
 
 -   source: The logo at the top of each form. Can be a Data URI or just a path to a image file you place in public/images, e.g. `"/images/mylogo.png"`.


### PR DESCRIPTION
Some redis databases are configured to use TLS - this is especially common if you use the AWS MemoryDB version of redis. This PR allows you to configure the redis client to work with TLS and redis in cluster mode. 

`prefix` is required for cluster
`tls` is required for tls connections

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?

- Tested with MemoryDB

#### Why is this the best possible solution? Were any other approaches considered?

 - This allows configuration of TLS/prefix in the app, but does not break existing configs

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

 - no affect

#### Do we need any specific form for testing your changes? If so, please attach one.

 - no
