### PR TITLE
feat(app): add enketo namespace to all debug statements

### DIFF
--- a/app/controllers/media-controller.js
+++ b/app/controllers/media-controller.js
@@ -8,7 +8,7 @@ const request = require('request');
 const express = require('express');
 
 const router = express.Router();
-const debug = require('debug')('media-controller');
+const debug = require('debug')('enketo:media-controller');
 const {
     RequestFilteringHttpAgent,
     RequestFilteringHttpsAgent,

--- a/app/lib/communicator.js
+++ b/app/lib/communicator.js
@@ -6,7 +6,7 @@ const request = require('request');
 const { Auth } = require('request/lib/auth');
 const TError = require('./custom-error').TranslatedError;
 const config = require('../models/config-model').server;
-const debug = require('debug')('openrosa-communicator');
+const debug = require('debug')('enketo:openrosa-communicator');
 const Xml2Js = require('xml2js');
 
 const parser = new Xml2Js.Parser();

--- a/app/models/cache-model.js
+++ b/app/models/cache-model.js
@@ -9,7 +9,7 @@ const utils = require('../lib/utils');
 
 const prefix = 'ca:';
 const expiry = 30 * 24 * 60 * 60;
-const debug = require('debug')('cache-model');
+const debug = require('debug')('enketo:cache-model');
 
 const clientGet = promisify(cacheClient.get).bind(cacheClient);
 const clientSet = promisify(cacheClient.set).bind(cacheClient);

--- a/app/models/survey-model.js
+++ b/app/models/survey-model.js
@@ -8,7 +8,7 @@ const TError = require('../lib/custom-error').TranslatedError;
 const config = require('./config-model').server;
 
 const pending = {};
-const debug = require('debug')('survey-model');
+const debug = require('debug')('enketo:survey-model');
 
 /**
  * @typedef {import('./account-model').AccountObj} AccountObj

--- a/config/express.js
+++ b/config/express.js
@@ -14,7 +14,7 @@ const errorHandler = require('../app/controllers/error-handler');
 
 const controllersPath = path.join(__dirname, '../app/controllers');
 const app = express();
-const debug = require('debug')('express');
+const debug = require('debug')('enketo:express');
 const config = require('../app/models/config-model');
 
 // general

--- a/tutorials/00-getting-started.md
+++ b/tutorials/00-getting-started.md
@@ -58,3 +58,11 @@ To configure your own custom external authentication also see [this document](ht
 Run with `npm start` from project root.
 
 You can now check that the app is running by going to e.g. http://localhost:8005 (depending on your server and port set in config/config.json or the port forwarding set up in Vagrant (default is 8006))
+
+### How to enable debug logs
+
+Enketo uses the npm `debug` module. All debug statements are prefixed with `enketo:` and will not appear unless the environment variable is set. To enable debugging logs for enketo specifically, set `DEBUG` as follows:
+
+```bash
+export DEBUG=enketo*
+```


### PR DESCRIPTION
This namespaces all `debug` statements so its easier to enable _only_ enketo logs. 

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?

Tested locally, and on a custom docker build

#### Why is this the best possible solution? Were any other approaches considered?

Its really difficult currently to see all debug logs for enketo only. Sure, we can set `DEBUG=*` but that gives us way too many logs from other modules that use `debug`. 

setting `DEBUG=enketo*` gives us more specificity. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Shouldn't affect end users, only administrators if they currently have the `DEBUG` variable set. 

#### Do we need any specific form for testing your changes? If so, please attach one.

No