### PR TITLE
Add support for LineString and Polygon GeoJSON types

### DIFF
--- a/test/client/feature/geojson-external-instance.spec.js
+++ b/test/client/feature/geojson-external-instance.spec.js
@@ -49,8 +49,8 @@ describe('GeoJSON external secondary instances', () => {
                 source: 'bad-feature-not-feature.geojson',
             },
             {
-                reason: 'if the geometry is not a point',
-                source: 'feature-collection-with-line.geojson',
+                reason: 'if the geometry is not supported',
+                source: 'feature-collection-with-unsupported-type.geojson',
             },
         ];
 
@@ -91,7 +91,7 @@ describe('GeoJSON external secondary instances', () => {
                 'feature-collection.geojson'
             );
 
-            expect(result.documentElement.childElementCount).to.equal(2);
+            expect(result.documentElement.childElementCount).to.equal(3);
             expect(
                 result.documentElement.children[0].querySelector('geometry')
                     .textContent
@@ -99,7 +99,11 @@ describe('GeoJSON external secondary instances', () => {
             expect(
                 result.documentElement.children[1].querySelector('geometry')
                     .textContent
-            ).to.equal('0.5 104 0 0');
+            ).to.equal('0.5 104 0 0; 0.5 105 0 0');
+            expect(
+                result.documentElement.children[2].querySelector('geometry')
+                    .textContent
+            ).to.equal('63 5 0 0; 83 10 0 0; 63 5 0 0');
         });
 
         it('adds all other properties as children', async () => {

--- a/test/fixtures/geojson/feature-collection-with-unsupported-type.geojson
+++ b/test/fixtures/geojson/feature-collection-with-unsupported-type.geojson
@@ -4,7 +4,7 @@
         {
             "type": "Feature",
             "geometry": {
-                "type": "LineString",
+                "type": "Foo",
                 "coordinates": [102, 0.5]
             },
             "properties": {

--- a/test/fixtures/geojson/feature-collection.geojson
+++ b/test/fixtures/geojson/feature-collection.geojson
@@ -16,14 +16,34 @@
         {
             "type": "Feature",
             "geometry": {
-                "type": "Point",
-                "coordinates": [104, 0.5]
+                "type": "LineString",
+                "coordinates": [
+                    [104, 0.5],
+                    [105, 0.5]
+                ]
             },
             "properties": {
                 "id": "67abie",
-                "name": "Your cool point",
+                "name": "Your cool line",
                 "foo": "quux",
                 "special-property": "special value"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [5, 63],
+                        [10, 83],
+                        [5, 63]
+                    ]
+                ]
+            },
+            "properties": {
+                "id": "32dyal",
+                "name": "Your cool polygon"
             }
         }
     ]


### PR DESCRIPTION
Closes #553.

This is largely based on https://github.com/getodk/javarosa/pull/707. The biggest divergence besides obvious language/API differences is the validation approach. And `@ts-check` was added to ensure the validation and types actually match the expected runtime values.

#### I have verified this PR works with

-   [x] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?

Added tests, though some from the JavaRosa change were skipped as they felt redundant.

#### Why is this the best possible solution? Were any other approaches considered?

-

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I think the risk of regression is low unless there's some mistake where the change touches existing code.

#### Do we need any specific form for testing your changes? If so, please attach one.

A suitable test form is attached to #553