### PR TITLE
Make pdf generation timeout configurable

### DIFF
--- a/app/lib/pdf.js
+++ b/app/lib/pdf.js
@@ -103,6 +103,7 @@ async function get(url, options = {}) {
             },
             scale: options.scale,
             printBackground: true,
+            timeout,
         });
     } catch (e) {
         e.status = e.status || 400;


### PR DESCRIPTION
Currently puppeteer's `pdf` function is not used with a timeout. OpenClinica has run into issues with long forms timing out before the `pdf` function completed (probably due to hitting an internal default timeout). The solution is to make this configurable. I think the already present config item `headless.timeout` can be used for this.

https://pptr.dev/api/puppeteer.pdfoptions

#### I have verified this PR works with
-   [x] PDF API endpoints

#### What else has been done to verify that this works as intended?

nothing

#### Why is this the best possible solution? Were any other approaches considered?

A new separate configuration item was considered but deemed unnecessary.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The default headless.timeout in default-config.json that will now be used is 300 seconds. OpenClinica was hitting a 30 second (mysterious) timeout before this change. So, I don't think there is a significant chance of regressions for users.

#### Do we need any specific form for testing your changes? If so, please attach one.

No specific form needed. PDF generation can be tested with e.g.

```bash
curl --user enketorules: -d "server_url=https://api.ona.io/enketo&form_id=widgets&instance=<widgets><text_widgets><text>mart</text></text_widgets><media_widgets><signature>test.jpg</signature></media_widgets></widgets>&instance_id=someUUID&instance_attachments[test.jpg]=https://upload.wikimedia.org/wikipedia/commons/a/a9/Example.jpg" http://localhost:8005/api/v2/instance/view/pdf > ~/Downloads/pdf1.pdf
```