### PR TITLE
$ sign should be encoded for media endpoint

### DIFF
--- a/app/lib/media.js
+++ b/app/lib/media.js
@@ -272,7 +272,7 @@ const getHostURLOptions = (request, mediaHash) => ({
     basePath: request.app.get('base path') ?? '',
     cookie: request.headers.cookie,
     mediaHash,
-    requestPath: request.url,
+    requestPath: request.url.replace(/\$/g, '%24'), // express special treatment of $ https://github.com/expressjs/express/issues/2987
 });
 
 /**


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/433

What's happing:

```
Request from browser:            `http://localhost/-/media/get/1/uuid:one/%24dollar-10_36_6.jpg`
request.url in getHostURLOption:                         `/get/1/uuid:one/$dollar-10_36_6.jpg`
```

`%24` is decoded to `$`, but if the request has `%2524` then it is not decoded to `%24` which is quite strange. To me it looks like it has something to do with this https://github.com/expressjs/express/issues/2987 - but I am not fully certain.

