### PR TITLE
Override Docker ENTRYPOINT so that PID 1 inside the container is correctly assigned

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,9 @@ VOLUME ${ENKETO_SRC_DIR}/setup/docker/secrets
 
 EXPOSE 8005
 
-CMD ${ENKETO_SRC_DIR}/setup/docker/start.sh
+# Override the base image's ENTRYPOINT instead of passing arguments to it using
+# CMD, and use the "exec form" to avoid spawning an intermediary shell.
+# NB: Docker will not expand environment variables like ENKETO_SRC_DIR within
+# the ENTRYPOINT instruction; see
+# https://docs.docker.com/engine/reference/builder/#environment-replacement
+ENTRYPOINT ["/srv/src/enketo_express/setup/docker/start.sh"]


### PR DESCRIPTION
`pm2-runtime` will now run as PID 1 as intended in #533. See also https://github.com/enketo/enketo-express/issues/531#issuecomment-1633255721.

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [x] None of the above
    (…because no application code has changed. If anyone feels they're warranted, however, I'm happy to carry out the tests.)

#### What else has been done to verify that this works as intended?
Verified `pm2-runtime` as PID 1 within the container using the following method:
```
john@world$ git show --oneline --no-patch
9f4d9aa0 (HEAD -> override-docker-entrypoint, origin/override-docker-entrypoint) Override Docker ENTRYPOINT so that PID 1 inside…
john@world$ docker build -t ee-test-entrypoint .
<snip>
Successfully tagged ee-test-entrypoint:latest

john@world$ docker run --rm --name ee-test-entrypoint ee-test-entrypoint &
[1] 428179
john@world$ 2023-07-12T22:55:19: PM2 log: Launching in no daemon mode
2023-07-12T22:55:19: PM2 log: App [enketo:0] starting in -fork mode-
2023-07-12T22:55:19: PM2 log: App [enketo:0] online
Worker 1 ready for duty at port 8005! (environment: production)
Worker 2 ready for duty at port 8005! (environment: production)

john@world$ docker exec -it ee-test-entrypoint ps x
    PID TTY      STAT   TIME COMMAND
      1 ?        Ssl    0:00 node /usr/local/bin/pm2-runtime app.js -n enketo
     19 ?        Ssl    0:00 node /srv/src/enketo_express/app.js
     72 ?        Sl     0:00 node /srv/src/enketo_express/app.js
     73 ?        Sl     0:00 node /srv/src/enketo_express/app.js
    116 pts/0    Rs+    0:00 ps x
```

#### Why is this the best possible solution? Were any other approaches considered?
The `CMD` instruction could've been modified instead of switching to `ENTRYPOINT`, but even if that did work, it would rely on a [convoluted execution path](https://github.com/enketo/enketo-express/issues/531#issuecomment-1465316065) that depends on some peculiar behavior of the `node:14` base image.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Systems administrators should notice that Enketo Docker containers exit cleanly and more quickly. I can't foresee any negative consequences. The change should have no impact on end users.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.