### PR TITLE
Fix/various pdf fixes

### DIFF
--- a/app/lib/headless-browser.js
+++ b/app/lib/headless-browser.js
@@ -1,0 +1,39 @@
+const puppeteer = require('puppeteer');
+
+const args = ['--no-startup-window'];
+const userDataDir = './chromium-cache';
+
+/**
+ * This class approach makes it easy to open multiple browser instances with
+ * different arguments in case that is ever required.
+ */
+class BrowserHandler {
+    constructor() {
+        const launchBrowser = async () => {
+            this.browser = false;
+            this.browser = await puppeteer.launch({
+                headless: true,
+                devtools: false,
+                args,
+                userDataDir,
+            });
+            this.browser.on('disconnected', launchBrowser);
+        };
+
+        (async () => {
+            await launchBrowser();
+        })();
+    }
+}
+
+const getBrowser = (handler) =>
+    new Promise((resolve) => {
+        const browserCheck = setInterval(() => {
+            if (handler.browser !== false) {
+                clearInterval(browserCheck);
+                resolve(handler.browser);
+            }
+        }, 100);
+    });
+
+module.exports = { BrowserHandler, getBrowser };

--- a/app/lib/pdf.js
+++ b/app/lib/pdf.js
@@ -1,12 +1,12 @@
 /**
  * @module pdf
  */
+const { URL } = require('url');
 const config = require('../models/config-model').server;
 const { BrowserHandler, getBrowser } = require('./headless-browser');
 
 const browserHandler = new BrowserHandler();
 const { timeout } = config.headless;
-const { URL } = require('url');
 
 /**
  * @typedef PdfGetOptions
@@ -36,21 +36,24 @@ const DEFAULTS = {
  * @param {PdfGetOptions} [options] - PDF options
  * @return { Promise } a promise that returns the PDF
  */
-async function get(url, options = {}) {
+async function get(
+    url,
+    {
+        format = DEFAULTS.FORMAT,
+        margin = DEFAULTS.MARGIN,
+        landscape = DEFAULTS.LANDSCAPE,
+        scale = DEFAULTS.SCALE,
+    } = {}
+) {
     if (!url) {
         throw new Error('No url provided');
     }
 
-    options.format = options.format || DEFAULTS.FORMAT;
-    options.margin = options.margin || DEFAULTS.MARGIN;
-    options.landscape = options.landscape || DEFAULTS.LANDSCAPE;
-    options.scale = options.scale || DEFAULTS.SCALE;
-
     const urlObj = new URL(url);
-    urlObj.searchParams.append('format', options.format);
-    urlObj.searchParams.append('margin', options.margin);
-    urlObj.searchParams.append('landscape', options.landscape);
-    urlObj.searchParams.append('scale', options.scale);
+    urlObj.searchParams.append('format', format);
+    urlObj.searchParams.append('margin', margin);
+    urlObj.searchParams.append('landscape', landscape);
+    urlObj.searchParams.append('scale', scale);
 
     const browser = await getBrowser(browserHandler);
     const page = await browser.newPage();
@@ -94,15 +97,15 @@ async function get(url, options = {}) {
         });
 
         pdf = await page.pdf({
-            landscape: options.landscape,
-            format: options.format,
+            landscape,
+            format,
             margin: {
-                top: options.margin,
-                left: options.margin,
-                right: options.margin,
-                bottom: options.margin,
+                top: margin,
+                left: margin,
+                right: margin,
+                bottom: margin,
             },
-            scale: options.scale,
+            scale,
             printBackground: true,
             timeout,
         });

--- a/app/lib/pdf.js
+++ b/app/lib/pdf.js
@@ -2,9 +2,10 @@
  * @module pdf
  */
 const config = require('../models/config-model').server;
+const { BrowserHandler, getBrowser } = require('./headless-browser');
 
+const browserHandler = new BrowserHandler();
 const { timeout } = config.headless;
-const puppeteer = require('puppeteer');
 const { URL } = require('url');
 
 /**
@@ -51,7 +52,7 @@ async function get(url, options = {}) {
     urlObj.searchParams.append('landscape', options.landscape);
     urlObj.searchParams.append('scale', options.scale);
 
-    const browser = await puppeteer.launch({ headless: true });
+    const browser = await getBrowser(browserHandler);
     const page = await browser.newPage();
 
     let pdf;
@@ -112,7 +113,6 @@ async function get(url, options = {}) {
     }
 
     await page.close();
-    await browser.close();
 
     return pdf;
 }


### PR DESCRIPTION
Offering some improvements that were made to PDF generation in OpenClinica's fork. PDF (record) generation is something their users use extensively.

#### I have verified this PR works with

-   [x] pdf generation API endpoint

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

- 1. Enketo used to instantiate a headless browser for each PDF API call and close this browser at the end of the call. The first commit of this PR changes that to a single browser instance that always remains open (and re-launches automatically if it crashes). API responses should therefore be faster.
- 2. There is a bug in PDF generation for forms that require authentication. The PDF logic is not able to open the form but **does not** respond with an error. Instead it produces an 'empty' PDF (actually a text file but with a pdf extension that is shown as an empty PDF by Preview). The 3rd commit in this PR fixes this by properly returning a 401 response. 


