### PR TITLE
Revert "Override Docker ENTRYPOINT…"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,4 @@ VOLUME ${ENKETO_SRC_DIR}/setup/docker/secrets
 
 EXPOSE 8005
 
-# Override the base image's ENTRYPOINT instead of passing arguments to it using
-# CMD, and use the "exec form" to avoid spawning an intermediary shell.
-# NB: Docker will not expand environment variables like ENKETO_SRC_DIR within
-# the ENTRYPOINT instruction; see
-# https://docs.docker.com/engine/reference/builder/#environment-replacement
-ENTRYPOINT ["/srv/src/enketo_express/setup/docker/start.sh"]
+CMD ${ENKETO_SRC_DIR}/setup/docker/start.sh


### PR DESCRIPTION
When run with downstream images [such as ODK Central's](https://github.com/getodk/central/blob/master/enketo.dockerfile), the `ENTRYPOINT` change (#571) results in 404 responses from the transformation API endpoint. As we're preparing a release (#581), we're temporarily rolling back that change so we can investigate further.