### PR TITLE
Fix versions in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 6.3.0 - 2023-08-18
+## 6.2.2 - 2023-08-22
+
+-   Fix changelog versions
+
+## 6.2.1 - 2023-08-21
 
 -   Update Docker base image to Node 16 (#578)
 -   Fix: multiple "static" itemset datalists in the same repeat (enketo/enketo-core#995)


### PR DESCRIPTION
I didn't notice an error in the changelog version! I think the best way to fix this is to update the version to match the tag and then release another patch. The changelog is displayed on running servers so it's important that the version actually matches the release tag.