### PR TITLE
DOC: Fixed outdated links.

### DIFF
--- a/tutorials/00-getting-started.md
+++ b/tutorials/00-getting-started.md
@@ -49,9 +49,9 @@ For development usages, it is helpful to set "linked form and data server" -> "s
 
 If you'd like to run a form server such as KoBoToolbox or ODK Aggregate or ODK Central on a private IP address during development, you need to add that IP address to "ip filtering" -> "allowIPAddressList".
 
-For detailed guidance on each configuration item, see {@tutorial 10-configuration}.
+For detailed guidance on each configuration item, see [the configuration tutorial](https://github.com/enketo/enketo-express/blob/master/tutorials/10-configure.md).
 
-To configure your own custom external authentication also see [this document](https://github.com/enketo/enketo-express/blob/master/tutorials/30-authentication-and-security.md).
+To configure your own custom external authentication also see [this document](https://github.com/enketo/enketo-express/blob/master/tutorials/60-authentication-and-security.md).
 
 ### How to run
 

--- a/tutorials/60-authentication-and-security.md
+++ b/tutorials/60-authentication-and-security.md
@@ -4,7 +4,7 @@ This app can manage [OpenRosa form authentication](https://bitbucket.org/javaros
 
 Alternatively, you could make use various _external authentication_ methods, i.e. using the authentication management of your form and data server.
 
-For more information see [this documentation page](https://enketo.org/develop/auth/) and the [configuration documentation](https://github.com/enketo/enketo-express/blob/master/tutorials/10-configuration.md#linked-form-and-data-server).
+For more information see [this documentation page](https://enketo.org/develop/auth/) and the [configuration documentation](https://github.com/enketo/enketo-express/blob/master/tutorials/10-configure.md#linked-form-and-data-server).
 
 ### Security
 


### PR DESCRIPTION
Closes #

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [x] None of the above -> Does not apply, only Markdown links.

#### What else has been done to verify that this works as intended?

- [x] Checked URLs.

#### Why is this the best possible solution? Were any other approaches considered?

Simply renamed links in documentation.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Documentation is updated, links will work again now.

#### Do we need any specific form for testing your changes? If so, please attach one.

ø
